### PR TITLE
Only track the last two Slices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(lsqecc)
 ####################################################
 # General configuration
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g -Wfatal-errors -Wall -pedantic -D_LIBCPP_DEBUG=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g -Wfatal-errors -Wall -pedantic -D_LIBCPP_DEBUG=1 -Wno-c++11-narrowing")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_BUILD_TYPE Debug)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(lsqecc)
 ####################################################
 # General configuration
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g -Wfatal-errors -Wall -pedantic -D_LIBCPP_DEBUG=1 -Wno-c++11-narrowing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g -Wfatal-errors -Wall -pedantic -D_LIBCPP_DEBUG=1")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_BUILD_TYPE Debug)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Options:
     -l, --layout           File name of file with layout spec. Defaults to simple layout if none is provided
     -o, --output           File name of output file to which write a latticesurgery.com JSON of the slices
     -t, --timeout          Set a timeout in seconds after which stop producing slices
-    -h, --help             Shows this page  
+    -s, --slice-tracking   Set a slice tracking policy: all (default), last_two
+    -r, --router           Set a router: naive_cached (default), naive
+    -h, --help             Shows this page
 ```
 
 #### The `liblsqecc` library

--- a/include/lsqecc/logical_lattice_ops/logical_lattice_ops.hpp
+++ b/include/lsqecc/logical_lattice_ops/logical_lattice_ops.hpp
@@ -31,7 +31,7 @@ struct MultiPatchMeasurement {
 struct PatchInit {
     PatchId target;
 
-    enum class InitializeableStates {
+    enum class InitializeableStates : uint8_t {
         Zero,
         Plus
     };
@@ -48,9 +48,9 @@ struct MagicStateRequest {
 struct SingleQubitOp {
     PatchId target;
 
-    enum class Operator {
-        X = static_cast<int>(PauliOperator::X),
-        Y = static_cast<int >(PauliOperator::Y),
+    enum class Operator : uint8_t {
+        X = static_cast<uint8_t>(PauliOperator::X),
+        Y = static_cast<uint8_t>(PauliOperator::Y),
         H,
         S,
     };

--- a/include/lsqecc/patches/fast_patch_computation.hpp
+++ b/include/lsqecc/patches/fast_patch_computation.hpp
@@ -14,6 +14,12 @@
 
 namespace lsqecc {
 
+
+enum class SliceTrackingPolicy
+{
+    KeepAll, KeepOnlyLastTwo
+};
+
 class PatchComputation
 {
 public:
@@ -22,29 +28,39 @@ public:
             const LogicalLatticeComputation& logical_computation,
             std::unique_ptr<Layout>&& layout,
             std::unique_ptr<Router>&& router,
-            std::optional<std::chrono::seconds> timeout);
+            std::optional<std::chrono::seconds> timeout,
+            SliceTrackingPolicy slice_tracking_policy);
+
+    const std::vector<Slice>& get_slices() const; // Requires KeepAll policy or throws an error
+    size_t slice_count() const;
+
+    const Layout& get_layout() const {return *layout_;}
 
 private:
 
     void make_slices(const LogicalLatticeComputation& logical_computation, std::optional<std::chrono::seconds> timeout);
 
     /// Assumes that there already is a slice
-    Slice& new_slice();
+    Slice& make_new_slice();
+    void accept_new_slice(Slice&& slice);
     Slice& last_slice();
+    Slice& second_last_slice();
 
-    std::unique_ptr<Layout> layout_;
-    std::unique_ptr<Router> router_;
-    std::vector<Slice> slices_;
-
-    std::vector<std::vector<lstk::bool8>> is_cell_free_;
-
-private:
     void compute_free_cells();
     std::optional<Cell> find_place_for_magic_state(size_t distillation_region_idx) const;
 
-public:
-    const std::vector<Slice>& get_slices()const {return slices_;}
-    const Layout& get_layout() const {return *layout_;}
+private: // Data members
+
+    std::unique_ptr<Layout> layout_;
+    std::unique_ptr<Router> router_;
+
+    using SlicesVector = std::vector<Slice>;
+    using SlicesPair = std::pair<Slice,Slice>;
+    std::variant<SlicesVector, SlicesPair> slices_;
+    size_t slice_count_ = 0;
+
+    // Cache which cells are free in the last slice to speed up search computations
+    std::vector<std::vector<lstk::bool8>> is_cell_free_;
 
 };
 

--- a/include/lsqecc/patches/patches.hpp
+++ b/include/lsqecc/patches/patches.hpp
@@ -25,15 +25,15 @@ enum class BoundaryType : uint8_t {
 BoundaryType boundary_for_operator(PauliOperator op);
 
 struct Cell {
-    using CoordinateType = int16_t;
+    using CoordinateType = int32_t;
     CoordinateType row;
     CoordinateType col;
 
     std::vector<Cell> get_neigbours() const;
     std::vector<Cell> get_neigbours_within_bounding_box_inclusive(const Cell& origin, const Cell& furthest_cell) const;
 
-    template<class IntType1, class IntType2>
-    static inline Cell from_ints(IntType1 _row, IntType2 _col)
+    template<class IntType>
+    static Cell from_ints(IntType _row, IntType _col)
     {
         return Cell{static_cast<Cell::CoordinateType>(_row),Cell::CoordinateType(_col)};
     };

--- a/include/lsqecc/patches/patches.hpp
+++ b/include/lsqecc/patches/patches.hpp
@@ -14,7 +14,7 @@
 
 namespace lsqecc {
 
-enum class BoundaryType {
+enum class BoundaryType : uint8_t {
     None, // Used by routing
     Connected, // Used for multi patch
     Rough,
@@ -41,14 +41,14 @@ struct Cell {
     bool operator==(const Cell&) const = default;
 };
 
-enum class PatchType {
+enum class PatchType : uint8_t {
     Distillation,
     PreparedState,
     Qubit,
     Routing
 };
 
-enum class PatchActivity
+enum class PatchActivity : uint8_t
 {
     None,
     Measurement,

--- a/include/lsqecc/patches/patches.hpp
+++ b/include/lsqecc/patches/patches.hpp
@@ -25,15 +25,15 @@ enum class BoundaryType : uint8_t {
 BoundaryType boundary_for_operator(PauliOperator op);
 
 struct Cell {
-    using CoordinateType = int32_t;
+    using CoordinateType = int16_t;
     CoordinateType row;
     CoordinateType col;
 
     std::vector<Cell> get_neigbours() const;
     std::vector<Cell> get_neigbours_within_bounding_box_inclusive(const Cell& origin, const Cell& furthest_cell) const;
 
-    template<class IntType>
-    static Cell from_ints(IntType _row, IntType _col)
+    template<class IntType1, class IntType2>
+    static inline Cell from_ints(IntType1 _row, IntType2 _col)
     {
         return Cell{static_cast<Cell::CoordinateType>(_row),Cell::CoordinateType(_col)};
     };

--- a/include/lsqecc/patches/slice.hpp
+++ b/include/lsqecc/patches/slice.hpp
@@ -13,7 +13,7 @@ struct Slice {
     std::vector<Patch> qubit_patches;
     std::vector<RoutingRegion> routing_regions;
     std::deque<Patch> unbound_magic_states;
-    const Layout& layout;
+    std::reference_wrapper<const Layout> layout;
     std::vector<SurfaceCodeTimestep> time_to_next_magic_state_by_distillation_region;
 
     Patch& get_patch_by_id_mut(PatchId id);
@@ -23,6 +23,8 @@ struct Slice {
     std::optional<std::reference_wrapper<const Patch>> get_any_patch_on_cell(const Cell& cell) const;
     bool is_cell_free(const Cell& cell) const;
     std::vector<Cell> get_neigbours_within_slice(const Cell& cell) const;
+    static Slice make_blank_slice(const Layout& layout);
+
 
     bool operator==(const Slice& other) const {
         return qubit_patches == other.qubit_patches

--- a/include/lsqecc/pauli_rotations/pauli_operator.hpp
+++ b/include/lsqecc/pauli_rotations/pauli_operator.hpp
@@ -7,7 +7,7 @@
 
 namespace lsqecc {
 
-enum class PauliOperator {
+enum class PauliOperator : uint8_t {
     I,
     X,
     Y,

--- a/src/layout/ascii_layout_spec.cpp
+++ b/src/layout/ascii_layout_spec.cpp
@@ -19,6 +19,8 @@ std::vector<std::vector<AsciiLayoutSpec::CellType>> AsciiLayoutSpec::parse_grid(
     std::vector<std::vector<AsciiLayoutSpec::CellType>> rows;
     for(const std::string_view& row: absl::StrSplit(input,'\n'))
     {
+        if(row.length() == 0) continue;
+
         rows.emplace_back();
         for(char c: row)
         {

--- a/src/layout/graph_search/boost_based_graph_search.cpp
+++ b/src/layout/graph_search/boost_based_graph_search.cpp
@@ -34,7 +34,7 @@ std::optional<RoutingRegion> graph_search_route_ancilla(
     std::vector<Vertex> vertices;
     std::vector<Edge> edges;
 
-    Cell furthest_cell = slice.layout.furthest_cell();
+    Cell furthest_cell = slice.layout.get().furthest_cell();
 
     auto make_vertex = [&furthest_cell](const Cell& cell) -> Vertex
     {

--- a/src/patches/slice.cpp
+++ b/src/patches/slice.cpp
@@ -60,7 +60,7 @@ std::optional<std::reference_wrapper<const Patch>> Slice::get_any_patch_on_cell(
 
 bool Slice::is_cell_free(const Cell& cell) const
 {
-    for(const auto& distillation_region: layout.distillation_regions())
+    for(const auto& distillation_region: layout.get().distillation_regions())
         for(const auto& distillation_cell: distillation_region.sub_cells)
             if(distillation_cell.cell==cell)
                 return false;
@@ -70,7 +70,17 @@ bool Slice::is_cell_free(const Cell& cell) const
 
 std::vector<Cell> Slice::get_neigbours_within_slice(const Cell& cell) const
 {
-    return cell.get_neigbours_within_bounding_box_inclusive({0,0}, layout.furthest_cell());
+    return cell.get_neigbours_within_bounding_box_inclusive({0,0}, layout.get().furthest_cell());
+}
+Slice Slice::make_blank_slice(const Layout& layout)
+{
+    return Slice{
+        .qubit_patches = {},
+        .routing_regions = {},
+        .unbound_magic_states = {},
+        .layout = {layout},
+        .time_to_next_magic_state_by_distillation_region = {},
+    };
 }
 
 }

--- a/src/patches/slices_to_json.cpp
+++ b/src/patches/slices_to_json.cpp
@@ -10,7 +10,7 @@ namespace lsqecc {
 json init_blank_json_slice(const Slice& slice)
 {
     json out_rows = json::array();
-    Cell furthest_cell = slice.layout.furthest_cell();
+    Cell furthest_cell = slice.layout.get().furthest_cell();
     for (int row_idx = 0; row_idx<=furthest_cell.row; ++row_idx)
     {
         json out_row = json::array();
@@ -105,7 +105,7 @@ json core_to_json(const Slice& slice)
     }
 
     size_t distillation_region_counter = 0;
-    for(const MultipleCellsOccupiedByPatch& distillation_region: slice.layout.distillation_regions())
+    for(const MultipleCellsOccupiedByPatch& distillation_region: slice.layout.get().distillation_regions())
     {
         bool placed_ttd = false;
         for(const SingleCellOccupiedByPatch& distillation_cell: distillation_region.sub_cells)


### PR DESCRIPTION
As per the data from #2, the bottleneck was memory usage. The PR adds the option to only track the last 2 slices:
<pre>
$ lsqecc_slicer <b>--slice-tracking last_two</b> -i ../benchmark/qft_50_instructions.txt -l 10_by_10_layout.txt
</pre>


### Benchmarks

#### Runtime
Now the memory bottleneck caused by storing patches is gone and can easily compile up to 50 qubits QFTs:
```
Reading LS Instructions
Read 9444076 instructions. Took 64.6876s.
Making patch computation
Made patch computation. Took 238.448s.
Generated 11627777 slices.
```
Fitting a quadratic with some more data points, we can estimate that it would take about 20 min to run a 100qubit QFT.
![image](https://user-images.githubusercontent.com/36427091/155841393-5d217444-402b-4fed-bf8d-dc15183a949a.png)


The only challenge is the massive size of the LS-Instructions file size which will be around 6 GB, but can also stream that.

Here is the profiler output of the 10 qubit QFT:
![Screenshot_20220226_082803](https://user-images.githubusercontent.com/36427091/155850936-d8241290-6bd8-4a4f-8110-2023286e01aa.png)


#### Memory
3 qubit QFT (can't do more because Valgrind is slow). Memory is taken up mostly by parsing
![HeapNoSliceTracking3Qubits](https://user-images.githubusercontent.com/36427091/155841055-d005cdaf-c3cc-44b4-a0ab-7fe570838c52.png)



### An idea for a stream processing API
Though we don't store slices we can still do something with them:
```cpp
for(const Slice& slice : patch_computation.stream_slices())
{
    // Do something with slice, like count routing patches or compute some statistic
}

```

