### PR TITLE
Reading instructions from STDIN and add option for machine friendly output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "external/ordered-map"]
 	path = external/ordered-map
 	url = https://github.com/Tessil/ordered-map.git
+[submodule "external/staq"]
+	path = external/staq
+	url = https://github.com/softwareQinc/staq

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 A collection of C++ tools to speed up the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler).
 
-Currently, its main goal is to produce a 3D assembly of "slices" representing routed LS Instructions.
-
-#### Structure
-This package builds two main targets, an executable and a library.
-
+### Targets
 #### The `lsqecc_slicer` executable
 
 Found at the top level of the build directory. Produces [latticesurgery.com](https://latticesurgery.com) style slices from [LS Instructions](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/246), using a [layout spec](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/250).
@@ -14,8 +10,12 @@ Found at the top level of the build directory. Produces [latticesurgery.com](htt
 Example usage: 
 
 ```shell
-lsqecc -i instructions.txt -l 10_by_10_layout.txt -o qft.json -t 5
+lsqecc_slicer -i instructions.txt -l 10_by_10_layout.txt -o output.json
 ```
+Where:
+ * `instructions.txt` contains [LS Instructions](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/246)
+ * `10_by_10_layout.txt` is a [layout spec](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/250) file.
+ * `output.json` is a file containing the 3D assembly of slices. Those can just be uploaded [latticesurgery.com](https://latticesurgery.com) for viewing
 
 Full usage:
 ```
@@ -40,11 +40,16 @@ Clone:
 $ git clone --recursive git@github.com:latticesurgery-com/liblsqecc.git 
 ```
 
+Install the [Boost](https://www.boost.org/) development headers for your platform.
+
 Standard CMake build:
 ```shell
 $ mkdir build
 $ cd build
 $ cmake ..
 ```
+
+The `lsqecc_slicer` executable will be at the top level of the `build` directory.
+
 
 ###

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Full usage:
 ```
 Usage: lsqecc_slicer [options...]
 Options:
-    -i, --instructions     File name of file with LS Instructions (Required)
+    -i, --instructions     File name of file with LS Instructions. If not provided will read from stdin
     -l, --layout           File name of file with layout spec. Defaults to simple layout if none is provided
     -o, --output           File name of output file to which write a latticesurgery.com JSON of the slices
     -t, --timeout          Set a timeout in seconds after which stop producing slices
     -r, --router           Set a router: naive_cached (default), naive
-    -h, --help             Shows this page
+    -f, --output-format    How to format output: progress (default), noprogres, machine
+    -h, --help             Shows this page 
 ```
 
 #### The `liblsqecc` library

--- a/include/lsqecc/gates/parse_gates.hpp
+++ b/include/lsqecc/gates/parse_gates.hpp
@@ -1,0 +1,8 @@
+#ifndef LSQECC_PARSE_GATES_HPP
+#define LSQECC_PARSE_GATES_HPP
+
+
+
+
+
+#endif //LSQECC_PARSE_GATES_HPP

--- a/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
+++ b/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <fstream>
+#include <fstream>
 #include <iterator>
 #include <cstddef>
 
@@ -18,14 +19,14 @@ class LSInstructionStream;
 
 class LSInstructionStream {
 public:
-    LSInstructionStream(std::ifstream&& instructions_file);
+    LSInstructionStream(std::istream& instructions_file);
 
     LSInstruction get_next_instruction();
     bool has_next_instruction() const {return next_instruction_.has_value();};
     const tsl::ordered_set<PatchId>& core_qubits() const {return core_qubits_;}
 
 private:
-    std::ifstream instructions_file_;
+    std::istream& instructions_file_;
     std::optional<LSInstruction> next_instruction_;
     tsl::ordered_set<PatchId> core_qubits_;
     size_t line_number_ = 0;

--- a/include/lsqecc/patches/fast_patch_computation.hpp
+++ b/include/lsqecc/patches/fast_patch_computation.hpp
@@ -46,6 +46,7 @@ public:
             SliceVisitorFunction slice_visitor);
 
     size_t slice_count() const {return slice_store_.slice_count();}
+    size_t ls_instructions_count() const {return ls_instructions_count_;}
 
 private:
 
@@ -69,6 +70,8 @@ private: // Data members
 
     // Cache which cells are free in the last slice to speed up search computations
     std::vector<std::vector<lstk::bool8>> is_cell_free_;
+
+    size_t ls_instructions_count_ = 0;
 
 };
 

--- a/src/ls_instructions/ls_instruction_stream.cpp
+++ b/src/ls_instructions/ls_instruction_stream.cpp
@@ -36,8 +36,8 @@ void LSInstructionStream::advance_instruction()
 }
 
 
-LSInstructionStream::LSInstructionStream(std::ifstream&& instructions_file)
-    :instructions_file_(std::move(instructions_file))
+LSInstructionStream::LSInstructionStream(std::istream& instructions_file)
+    :instructions_file_(instructions_file)
 {
 
     advance_instruction();

--- a/src/patches/fast_patch_computation.cpp
+++ b/src/patches/fast_patch_computation.cpp
@@ -131,6 +131,7 @@ void PatchComputation::make_slices(
         SliceVisitorFunction slice_visitor)
 {
     slice_store_.accept_new_slice(first_slice_from_layout(*layout_, instruction_stream.core_qubits()));
+    ls_instructions_count_++;
     compute_free_cells();
 
     auto start = std::chrono::steady_clock::now();
@@ -139,6 +140,8 @@ void PatchComputation::make_slices(
     while (instruction_stream.has_next_instruction())
     {
         LSInstruction instruction = instruction_stream.get_next_instruction();
+        ls_instructions_count_++;
+
         if (const auto* s = std::get_if<SinglePatchMeasurement>(&instruction.operation))
         {
             Slice& slice = make_new_slice();


### PR DESCRIPTION
Enables us to run benchmarks with piping directly from the [QFT generator](https://github.com/latticesurgery-com/benchmark/pull/1).