### PR TITLE
Fix graph search not merging neighbour patches directly

### DIFF
--- a/src/layout/graph_search/custom_graph_search.cpp
+++ b/src/layout/graph_search/custom_graph_search.cpp
@@ -78,7 +78,7 @@ std::optional<RoutingRegion> do_graph_search_route_ancilla(
 
         if(a == cell_from_vertex(source_vertex) && b == cell_from_vertex(target_vertex))
             return source_patch.have_boundary_of_type_with(source_op, b)
-                && source_patch.have_boundary_of_type_with(target_op, a);
+                && target_patch.have_boundary_of_type_with(target_op, a);
 
         if(a == cell_from_vertex(source_vertex) && slice.is_cell_free(b))
             return source_patch.have_boundary_of_type_with(source_op, b);
@@ -88,7 +88,6 @@ std::optional<RoutingRegion> do_graph_search_route_ancilla(
 
         return false;
     };
-
 
     size_t num_vertices_on_lattice = make_vertex(furthest_cell) + 1;
     std::vector<PredecessorData> predecessor_map(num_vertices_on_lattice);


### PR DESCRIPTION
Circuit:
```
DeclareLogicalQubitPatches 0,1,2,3,4,5,6
Init 100 +
MultiBodyMeasure 0:X,4:X
MultiBodyMeasure 5:Z,6:Z
MultiBodyMeasure 2:Z,3:Z
```

### Before
![Screenshot_20220405_024147](https://user-images.githubusercontent.com/36427091/161726296-7503abb0-8f92-480a-9926-e7d8c300d04d.png)


### After
![Screenshot_20220405_023209](https://user-images.githubusercontent.com/36427091/161724567-988de7a2-b7c4-4019-a89b-e63c4c18eba1.png)

