### PR TITLE
Basic Parallelization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(external/include)
 add_library(
         lsqecclib
         src/gates/parse_gates.cpp
-        src/patches/fast_patch_computation.cpp
+        src/patches/patch_computation.cpp
         src/ls_instructions/ls_instructions.cpp
         src/ls_instructions/ls_instructions_parse.cpp
         src/ls_instructions/ls_instruction_stream.cpp

--- a/examples/parallelize_instructions.lsi
+++ b/examples/parallelize_instructions.lsi
@@ -1,0 +1,9 @@
+DeclareLogicalQubitPatches 0,1,2,3,4,5,6
+Init 100 +
+MultiBodyMeasure 0:X,4:X
+MultiBodyMeasure 5:Z,6:Z
+MultiBodyMeasure 2:Z,3:Z
+RotateSingleCellPatch 100
+HGate 1
+HGate 1
+RotateSingleCellPatch 1

--- a/include/lsqecc/ls_instructions/ls_instructions.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions.hpp
@@ -3,6 +3,7 @@
 
 #include <variant>
 #include <stdexcept>
+#include <ostream>
 #include <unordered_set>
 #include <lsqecc/patches/patches.hpp>
 
@@ -49,7 +50,9 @@ struct PatchInit {
 
 struct MagicStateRequest {
     PatchId target;
+    size_t wait_at_most_for;
 
+    static const size_t DEFAULT_WAIT = 10;
     bool operator==(const MagicStateRequest&) const = default;
 };
 
@@ -75,6 +78,16 @@ struct SingleQubitOp {
     bool operator==(const SingleQubitOp&) const = default;
 };
 
+
+struct BusyRegion{
+    RoutingRegion region;
+    size_t steps_to_clear;
+    Patch state_after_clearing;
+
+    bool operator==(const BusyRegion&) const = default;
+};
+
+
 struct LSInstruction {
     std::variant<
             DeclareLogicalQubitPatches,
@@ -83,7 +96,8 @@ struct LSInstruction {
             PatchInit,
             MagicStateRequest,
             SingleQubitOp,
-            RotateSingleCellPatch> operation;
+            RotateSingleCellPatch,
+            BusyRegion> operation;
 
     std::vector<PatchId> get_operating_patches() const;
     bool operator==(const LSInstruction&) const = default;
@@ -95,6 +109,8 @@ struct InMemoryLogicalLatticeComputation
     std::vector<LSInstruction> instructions;
 };
 
+
+std::ostream& operator<<(std::ostream& os, const LSInstruction& instruction);
 
 }
 

--- a/include/lsqecc/patches/fast_patch_computation.hpp
+++ b/include/lsqecc/patches/fast_patch_computation.hpp
@@ -52,8 +52,8 @@ private:
 
     void make_slices(
             LSInstructionStream&& instruction_stream,
-            std::optional<std::chrono::seconds> timeout,
-            SliceVisitorFunction slice_visitor);
+            std::optional<std::chrono::seconds> timeout);
+
 
     /// Assumes that there already is a slice
     Slice& make_new_slice();
@@ -61,10 +61,10 @@ private:
     void compute_free_cells();
 
     std::optional<Cell> find_place_for_magic_state(size_t distillation_region_idx) const;
-    void merge_patches(Slice& slice, PatchId source, PauliOperator source_op, PatchId target, PauliOperator target_op);
 
 private: // Data members
     SliceStore slice_store_;
+    SliceVisitorFunction slice_visitor_;
 
     std::unique_ptr<Layout> layout_;
     std::unique_ptr<Router> router_;

--- a/include/lsqecc/patches/patch_computation.hpp
+++ b/include/lsqecc/patches/patch_computation.hpp
@@ -1,5 +1,5 @@
-#ifndef LSQECC_FAST_PATCH_COMPUTATION_HPP
-#define LSQECC_FAST_PATCH_COMPUTATION_HPP
+#ifndef LSQECC_PATCH_COMPUTATION_HPP
+#define LSQECC_PATCH_COMPUTATION_HPP
 
 
 #include <lsqecc/ls_instructions/ls_instructions.hpp>
@@ -79,4 +79,4 @@ private: // Data members
 
 }
 
-#endif //LSQECC_FAST_PATCH_COMPUTATION_HPP
+#endif //LSQECC_PATCH_COMPUTATION_HPP

--- a/include/lsqecc/patches/patch_computation.hpp
+++ b/include/lsqecc/patches/patch_computation.hpp
@@ -23,6 +23,7 @@ public:
     explicit SliceStore(const Layout& layout); // start with blank slices no initialization. i.e. slice_count_ = 0
     void accept_new_slice(Slice&& slice);
     Slice& last_slice() {return last_slice_;}
+    const Slice& last_slice_const() const {return last_slice_;}
     Slice& second_last_slice() {return second_last_slice_;}
     size_t slice_count() const { return slice_count_;};
 private:
@@ -31,6 +32,9 @@ private:
     size_t slice_count_ = 0;
 };
 
+
+using FreeCellCache = std::vector<std::vector<lstk::bool8>>;
+void compute_free_cells(FreeCellCache& is_cell_free, const Slice& slice);
 
 class PatchComputation
 {
@@ -58,8 +62,6 @@ private:
     /// Assumes that there already is a slice
     Slice& make_new_slice();
 
-    void compute_free_cells();
-
     std::optional<Cell> find_place_for_magic_state(size_t distillation_region_idx) const;
 
 private: // Data members
@@ -70,7 +72,7 @@ private: // Data members
     std::unique_ptr<Router> router_;
 
     // Cache which cells are free in the last slice to speed up search computations
-    std::vector<std::vector<lstk::bool8>> is_cell_free_;
+    mutable FreeCellCache is_cell_free_;
 
     size_t ls_instructions_count_ = 0;
 

--- a/include/lsqecc/patches/patches.hpp
+++ b/include/lsqecc/patches/patches.hpp
@@ -97,7 +97,9 @@ struct Patch{
     std::vector<Cell> get_cells() const;
     const Cell& get_a_cell() const;
     bool operator==(const Patch&) const = default;
-    void visit_individual_cells(void (v)(SingleCellOccupiedByPatch& c));
+    void visit_individual_cells_mut(std::function<void (SingleCellOccupiedByPatch&)> f);
+    void visit_individual_cells(std::function<void (const SingleCellOccupiedByPatch&)> f) const;
+    bool is_active() const;
 };
 
 struct RoutingRegion

--- a/include/lsqecc/patches/patches.hpp
+++ b/include/lsqecc/patches/patches.hpp
@@ -70,6 +70,7 @@ struct SingleCellOccupiedByPatch{
 
     std::optional<Boundary> get_boundary_with(const Cell& neighbour) const;
     bool have_boundary_of_type_with(PauliOperator op, const Cell& neighbour) const;
+    bool has_active_boundary() const;
     std::optional<std::reference_wrapper<Boundary>> get_mut_boundary_with(const Cell& neighbour);
 
     Cell cell;

--- a/include/lsqecc/patches/slice.hpp
+++ b/include/lsqecc/patches/slice.hpp
@@ -14,12 +14,14 @@ struct Slice {
     std::vector<Patch> qubit_patches;
     std::vector<RoutingRegion> routing_regions;
     std::deque<Patch> unbound_magic_states;
-    std::reference_wrapper<const Layout> layout;
+    std::reference_wrapper<const Layout> layout; // reference_wrapper Keeps the slice copyable
     std::vector<SurfaceCodeTimestep> time_to_next_magic_state_by_distillation_region;
 
-    Patch& get_patch_by_id_mut(PatchId id);
 
+    bool has_patch(PatchId id) const;
+    Patch& get_patch_by_id_mut(PatchId id);
     const Patch& get_patch_by_id(PatchId id) const;
+
     void delete_qubit_patch(PatchId id);
 
     const SingleCellOccupiedByPatch& get_single_cell_occupied_by_patch_by_id(PatchId id) const;

--- a/include/lsqecc/patches/slices_to_json.hpp
+++ b/include/lsqecc/patches/slices_to_json.hpp
@@ -1,7 +1,7 @@
 #ifndef LSQECC_SLICES_TO_JSON_HPP
 #define LSQECC_SLICES_TO_JSON_HPP
 
-#include <lsqecc/patches/fast_patch_computation.hpp>
+#include <lsqecc/patches/patch_computation.hpp>
 #include <nlohmann/json.hpp>
 
 namespace lsqecc {

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -131,9 +131,9 @@ void vector_extend(std::vector<T> &target, const std::vector<T> &extend_with)
 }
 
 template<class T>
-T queue_pop(std::queue<T> queue)
+T queue_pop(std::queue<T>& queue)
 {
-    T v = queue.front();
+    T v{std::move(queue.front())};
     queue.pop();
     return v;
 }

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -34,7 +34,10 @@ std::vector<PatchId> LSInstruction::get_operating_patches() const
     return ret;
 }
 
-
+std::ostream& operator<<(std::ostream& os, const LSInstruction& instruction)
+{
+    return os << "<An LS Instruction>";
+}
 
 
 }

--- a/src/ls_instructions/ls_instructions_parse.cpp
+++ b/src/ls_instructions/ls_instructions_parse.cpp
@@ -76,7 +76,7 @@ LSInstruction parse_ls_instruction(std::string_view line)
     else if(instruction == "RequestMagicState" || instruction == "3")
     {
         auto patch_id = parse_patch_id(get_next_arg());
-        return {MagicStateRequest{patch_id}};
+        return {MagicStateRequest{patch_id,MagicStateRequest::DEFAULT_WAIT}};
     }
     else if (instruction == "LogicalPauli" || instruction == "4")
     {

--- a/src/lsqecclib_pybind.cpp
+++ b/src/lsqecclib_pybind.cpp
@@ -1,6 +1,6 @@
 #include <pybind11/pybind11.h>
 
-#include <lsqecc/patches/fast_patch_computation.hpp>
+#include <lsqecc/patches/patch_computation.hpp>
 
 int fast_make_computation(int i)
 {

--- a/src/patches/patch_computation.cpp
+++ b/src/patches/patch_computation.cpp
@@ -81,7 +81,7 @@ Slice& PatchComputation::make_new_slice()
             if (new_patch.activity==PatchActivity::Unitary)
                 new_patch.activity = PatchActivity::None;
 
-            new_patch.visit_individual_cells([](SingleCellOccupiedByPatch& c)
+            new_patch.visit_individual_cells_mut([](SingleCellOccupiedByPatch& c)
             {
                c.top.is_active = false;
                c.bottom.is_active = false;
@@ -166,13 +166,7 @@ bool merge_patches(
         PauliOperator target_op)
 {
 
-    if(slice.get_patch_by_id(source).activity != PatchActivity::None
-    || slice.get_patch_by_id(source).activity != PatchActivity::None)
-        return false;
-
-    auto source_occupied_cell = slice.get_single_cell_occupied_by_patch_by_id(source);
-    auto target_occupied_cell = slice.get_single_cell_occupied_by_patch_by_id(target);
-    if(source_occupied_cell.has_active_boundary() || target_occupied_cell.has_active_boundary())
+    if(slice.get_patch_by_id(source).is_active() || slice.get_patch_by_id(target).is_active())
         return false;
 
     auto routing_region = router.find_routing_ancilla(slice, source, source_op, target, target_op);
@@ -232,7 +226,7 @@ void PatchComputation::make_slices(
 
             if(!merge_patches(slice_store_.last_slice(), *router_, source_id, source_op, target_id, target_op))
             {
-                Slice& slice = make_new_slice();
+                make_new_slice();
                 if(!merge_patches(slice_store_.last_slice(), *router_, source_id, source_op, target_id, target_op))
                     throw std::runtime_error{ lstk::cat("Couldn't find room to route: ",
                             source_id , ":" , PauliOperator_to_string(source_op), ",",

--- a/src/patches/patch_computation.cpp
+++ b/src/patches/patch_computation.cpp
@@ -361,8 +361,7 @@ void PatchComputation::make_slices(
     slice_store_.accept_new_slice(first_slice_from_layout(*layout_, instruction_stream.core_qubits()));
     ls_instructions_count_++; // The declare qubits instruction
 
-    // Add a blank slice for visualization
-    slice_visitor_(slice_store_.last_slice());
+    // Add a blank slice for the initial visualization of the layout
     make_new_slice();
 
     auto start = std::chrono::steady_clock::now();

--- a/src/patches/patch_computation.cpp
+++ b/src/patches/patch_computation.cpp
@@ -1,5 +1,5 @@
 #include <lsqecc/patches/patches.hpp>
-#include <lsqecc/patches/fast_patch_computation.hpp>
+#include <lsqecc/patches/patch_computation.hpp>
 #include <lsqecc/layout/router.hpp>
 
 #include <lstk/lstk.hpp>

--- a/src/patches/patches.cpp
+++ b/src/patches/patches.cpp
@@ -118,6 +118,11 @@ std::optional<std::reference_wrapper<Boundary>> SingleCellOccupiedByPatch::get_m
 
     return std::nullopt;
 }
+bool SingleCellOccupiedByPatch::has_active_boundary() const
+{
+    auto neighbours = cell.get_neigbours();
+    return std::any_of(neighbours.begin(), neighbours.end(), [&](auto n){return get_boundary_with(n)->is_active;});
 
+}
 
 }

--- a/src/patches/slice.cpp
+++ b/src/patches/slice.cpp
@@ -6,27 +6,26 @@
 namespace lsqecc{
 
 
-
-Patch& Slice::get_patch_by_id_mut(PatchId id) {
+bool Slice::has_patch(PatchId id) const
+{
     for(auto& p: qubit_patches)
-    {
         if(p.id == id)
-        {
+            return true;
+    return false;
+}
+
+Patch& Slice::get_patch_by_id_mut(PatchId id)
+{
+    for(auto& p: qubit_patches)
+        if(p.id == id)
             return p;
-        }
-    }
+
     throw std::logic_error(std::string{"No patch for id: "+std::to_string(id)});
 }
 
-const Patch& Slice::get_patch_by_id(PatchId id) const {
-    for(auto& p: qubit_patches)
-    {
-        if(p.id == id)
-        {
-            return p;
-        }
-    }
-    throw std::logic_error(std::string{"No patch for id: "+std::to_string(id)});
+const Patch& Slice::get_patch_by_id(PatchId id) const
+{
+    return const_cast<Slice*>(this)->get_patch_by_id_mut(id);
 }
 
 void Slice::delete_qubit_patch(PatchId id)
@@ -102,5 +101,6 @@ SingleCellOccupiedByPatch &Slice::get_single_cell_occupied_by_patch_by_id_mut(Pa
     return *patch;
 
 }
+
 
 }

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -5,7 +5,7 @@
 #include <lsqecc/layout/ascii_layout_spec.hpp>
 #include <lsqecc/layout/router.hpp>
 #include <lsqecc/patches/slices_to_json.hpp>
-#include <lsqecc/patches/fast_patch_computation.hpp>
+#include <lsqecc/patches/patch_computation.hpp>
 
 #include <lstk/lstk.hpp>
 

--- a/tests/patches/fast_patch_computation.cpp
+++ b/tests/patches/fast_patch_computation.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <lsqecc/patches/fast_patch_computation.hpp>
+#include <lsqecc/patches/patch_computation.hpp>
 
 using namespace lsqecc;
 


### PR DESCRIPTION
Try to parallelize instructions when one after the other. 

Can parallelize single patch transversal operations and multi body measurements, when they don't cross.

The algorithm looks only directly at the next instruction and if it can't parallelize it will create a new slice, even if the following instructions can be parallelized with the first. So it is recommended to pre-order instructions in layers to exploit this parallezing ability.

Instructions that take more than one slice like S gates and patch boundary rotations always create a new slice.

#### Example
```
DeclareLogicalQubitPatches 0,1,2,3,4,5,6
Init 100 +
MultiBodyMeasure 0:X,4:X
MultiBodyMeasure 5:Z,6:Z
MultiBodyMeasure 2:Z,3:Z
RotateSingleCellPatch 100
HGate 1
HGate 1
RotateSingleCellPatch 1
```

![BasicParallelization](https://user-images.githubusercontent.com/36427091/161940637-fcbbd4cd-9511-43e3-8f19-bae57bc33e3e.gif)
