### PR TITLE
Add parsing of a subset of OpenQASM and correspoding LLI generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(
         src/layout/ascii_layout_spec.cpp
         src/layout/layout.cpp
         src/pipelines/slicer.cpp
-        src/gates/gates.cpp src/patches/dense_slice.cpp src/patches/dense_patch_computation.cpp)
+        src/gates/gates.cpp src/patches/dense_slice.cpp src/patches/dense_patch_computation.cpp src/ls_instructions/ls_instructions_from_gates.cpp)
 
 set(LSQECCLIB_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ set(CMAKE_CXX_STANDARD 20)
 #set(CMAKE_BUILD_TYPE Debug)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    message("Setting stdlib=libc++")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
 endif ()
 
 
@@ -60,7 +62,10 @@ add_library(
         src/layout/ascii_layout_spec.cpp
         src/layout/layout.cpp
         src/pipelines/slicer.cpp
-        src/gates/gates.cpp src/patches/dense_slice.cpp src/patches/dense_patch_computation.cpp src/ls_instructions/ls_instructions_from_gates.cpp)
+        src/gates/gates.cpp
+        src/patches/dense_slice.cpp
+        src/patches/dense_patch_computation.cpp
+        src/ls_instructions/ls_instructions_from_gates.cpp)
 
 set(LSQECCLIB_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A collection of C++ tools to speed up the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler).
 
-### Targets
-#### The `lsqecc_slicer` executable
+## Targets
+### The `lsqecc_slicer` executable
 
 Found at the top level of the build directory. Produces [latticesurgery.com](https://latticesurgery.com) style slices from [LS Instructions](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/246), using a [layout spec](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/250).
  
@@ -33,12 +33,18 @@ Options:
     --graceful             If there is an error when slicing, print the error and terminate
     -h, --help             Shows this page   
 ```
+#### QASM Support
+LibLSQECC can parse a small subset of QASM 2.0 instead of LLI, with the following restrictions:
+ * Only one register is allowed (whether the names match will not be checked)
+ * Single qubit gates must be in the form `g q[n]` where `g` is one of `h,x,z,s,t` and `n` is a non-negative integer
+ * CNOTs must be in the form `cx q[n],q[m]` where `n,m` are non-negative
 
-#### The `liblsqecc` library
+
+### The `liblsqecc` library
 
 Contains the functionality used by the `lsqecc_slicer` executable. One day we hope to expose it's functionality as a Python API in the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler) package.
 
-#### Build
+### Build
 Clone:
 ```shell
 $ git clone --recursive git@github.com:latticesurgery-com/liblsqecc.git 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ Options:
     -g, --graph-search     Set a graph search provider: custom (default), boost (not allways available)
     -a, --slice-repr       Set how slices are represented: dense (default), sparse
     --graceful             If there is an error when slicing, print the error and terminate
+    --lli                  Output LLI instead of JSONs
     -h, --help             Shows this page   
 ```
-#### QASM Support
+#### QASM Support (Highly experimental)
 LibLSQECC can parse a small subset of QASM 2.0 instead of LLI, with the following restrictions:
  * Only one register is allowed (whether the names match will not be checked)
- * Single qubit gates must be in the form `g q[n]` where `g` is one of `h,x,z,s,t` and `n` is a non-negative integer
- * CNOTs must be in the form `cx q[n],q[m]` where `n,m` are non-negative
+ * Single qubit gates must be in the form `g q[n]` where `g` is one of `h`,`x`,`z`,`s`,`t` and `n` is a non-negative integer
+ * CNOTs must be in the form `cx q[n],q[m]` where `n` and `m` are non-negative. Target comes first, as per [OpenQASM convention (Fig 2)](https://arxiv.org/pdf/1707.03429.pdf).
 
+Working on adding support for `rz` and `crz`. Needs integration with a Solovay-Kitaev decomposer.
 
 ### The `liblsqecc` library
 

--- a/include/lsqecc/gates/gates.hpp
+++ b/include/lsqecc/gates/gates.hpp
@@ -18,13 +18,13 @@ struct Fraction{
 };
 
 
-using QubitNum = size_t;
+using QubitNum = uint32_t;
 
 
 namespace gates
 {
 
-struct BasicGate{
+struct BasicSingleQubitGate{
     enum class Type : uint8_t
     {
         X = static_cast<uint8_t>(PauliOperator::X),
@@ -47,7 +47,7 @@ struct RZ
 };
 
 
-using SingleQubitGate = std::variant<BasicGate, RZ>;
+using SingleQubitGate = std::variant<BasicSingleQubitGate, RZ>;
 
 struct ControlledGate
 {
@@ -59,8 +59,8 @@ struct ControlledGate
 
 
 #define MAKE_BASIC_GATE(G)\
-inline constexpr BasicGate G(QubitNum target_qubit){\
-    return BasicGate{target_qubit, BasicGate::Type::G};\
+inline constexpr BasicSingleQubitGate G(QubitNum target_qubit){\
+    return BasicSingleQubitGate{target_qubit, BasicSingleQubitGate::Type::G};\
 }
 
 MAKE_BASIC_GATE(X);
@@ -80,7 +80,7 @@ inline constexpr ControlledGate CRZ(QubitNum target_qubit, QubitNum control_qubi
     return {target_qubit, RZ{target_qubit, pi_fraction}};
 }
 
-using Gate = std::variant<BasicGate, RZ, ControlledGate>;
+using Gate = std::variant<BasicSingleQubitGate, RZ, ControlledGate>;
 
 } // gates namespace
 

--- a/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
+++ b/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
@@ -64,6 +64,8 @@ private:
 };
 
 
+std::ostream& print_all_ls_instructions_to_string(std::ostream& os, std::unique_ptr<LSInstructionStream>&& ls_instruction_stream);
+
 
 }
 

--- a/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
+++ b/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
@@ -2,6 +2,7 @@
 #define LSQECC_LS_INSTRUCTION_STREAM_HPP
 
 #include <lsqecc/ls_instructions/ls_instructions.hpp>
+#include <lsqecc/ls_instructions/ls_instructions_from_gates.hpp>
 #include <lsqecc/gates/parse_gates.hpp>
 
 
@@ -54,9 +55,11 @@ public:
     const tsl::ordered_set<PatchId>& core_qubits() const override;
 
 private:
+
     GateStream& gate_stream_;
     std::queue<LSInstruction> next_instructions_;
     tsl::ordered_set<PatchId> core_qubits_;
+    LSIinstructionFromGatesGenerator instruction_generator_;
     size_t line_number_ = 0;
 };
 

--- a/include/lsqecc/ls_instructions/ls_instructions.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions.hpp
@@ -71,7 +71,7 @@ struct SingleQubitOp {
         X = static_cast<uint8_t>(PauliOperator::X),
         Z = static_cast<uint8_t>(PauliOperator::Z),
         H,
-        S,
+        S
     };
 
     Operator op;
@@ -98,7 +98,8 @@ struct LSInstruction {
             MagicStateRequest,
             SingleQubitOp,
             RotateSingleCellPatch,
-            BusyRegion> operation;
+            BusyRegion
+            > operation;
 
     std::vector<PatchId> get_operating_patches() const;
     bool operator==(const LSInstruction&) const = default;
@@ -112,6 +113,92 @@ struct InMemoryLogicalLatticeComputation
 
 
 std::ostream& operator<<(std::ostream& os, const LSInstruction& instruction);
+
+std::ostream& operator<<(std::ostream& os, const DeclareLogicalQubitPatches& instruction);
+std::ostream& operator<<(std::ostream& os, const SinglePatchMeasurement& instruction);
+std::ostream& operator<<(std::ostream& os, const MultiPatchMeasurement& instruction);
+std::ostream& operator<<(std::ostream& os, const PatchInit& instruction);
+std::ostream& operator<<(std::ostream& os, const MagicStateRequest& instruction);
+std::ostream& operator<<(std::ostream& os, const SingleQubitOp& instruction);
+std::ostream& operator<<(std::ostream& os, const RotateSingleCellPatch& instruction);
+std::ostream& operator<<(std::ostream& os, const BusyRegion& instruction);
+
+template <class T>
+struct LSInstructionPrint{static constexpr std::string_view name = "<LSInstruction>";};
+
+
+// TODO this mapping is not consistent, go through the codebase and make it so
+template<>
+struct LSInstructionPrint<DeclareLogicalQubitPatches>{
+    static constexpr std::string_view name = "DeclareLogicalQubitPatches";
+};
+
+template<>
+struct LSInstructionPrint<SinglePatchMeasurement>{
+    static constexpr std::string_view name = "MeasureSinglePatch";
+};
+
+template<>
+struct LSInstructionPrint<MultiPatchMeasurement>{
+    static constexpr std::string_view name = "MeasureSinglePatch";
+};
+
+template<>
+struct LSInstructionPrint<PatchInit>{
+    static constexpr std::string_view name = "Init";
+};
+
+template<>
+struct LSInstructionPrint<MagicStateRequest>{
+    static constexpr std::string_view name = "RequestMagicState";
+};
+
+template<>
+struct LSInstructionPrint<SingleQubitOp>{
+    static constexpr std::string_view name = "Gate";
+};
+
+template<>
+struct LSInstructionPrint<RotateSingleCellPatch>
+{
+    static constexpr std::string_view name = "RotateSingleCellPatch";
+};
+
+template<>
+struct LSInstructionPrint<BusyRegion>{
+    static constexpr std::string_view name = "BusyRegion";
+};
+
+
+
+template <PatchInit::InitializeableStates State>
+struct InitializeableStatePrint{static constexpr std::string_view name = "<PatchInit::InitializeableState";};
+
+static inline std::string_view InitializeableStates_to_string(PatchInit::InitializeableStates state)
+{
+    using namespace std::string_view_literals;
+    switch(state)
+    {
+        case PatchInit::InitializeableStates::Zero:
+            return "|0>"sv;
+        case PatchInit::InitializeableStates::Plus:
+            return "|+>"sv;
+    }
+}
+
+
+static inline std::string_view SingleQuibitOperatorName_to_string(SingleQubitOp::Operator op)
+{
+    using namespace std::string_view_literals;
+    switch(op)
+    {
+        case SingleQubitOp::Operator::X: return "X"sv;
+        case SingleQubitOp::Operator::Z: return "Z"sv;
+        case SingleQubitOp::Operator::H: return "H"sv;
+        case SingleQubitOp::Operator::S: return "S"sv;
+    }
+}
+
 
 }
 

--- a/include/lsqecc/ls_instructions/ls_instructions.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions.hpp
@@ -63,6 +63,7 @@ struct RotateSingleCellPatch {
     bool operator==(const RotateSingleCellPatch&) const = default;
 };
 
+// TODO rename to transversal?
 struct SingleQubitOp {
     PatchId target;
 

--- a/include/lsqecc/ls_instructions/ls_instructions.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions.hpp
@@ -124,7 +124,7 @@ std::ostream& operator<<(std::ostream& os, const RotateSingleCellPatch& instruct
 std::ostream& operator<<(std::ostream& os, const BusyRegion& instruction);
 
 template <class T>
-struct LSInstructionPrint{static constexpr std::string_view name = "<LSInstruction>";};
+struct LSInstructionPrint{};
 
 
 // TODO this mapping is not consistent, go through the codebase and make it so
@@ -172,7 +172,7 @@ struct LSInstructionPrint<BusyRegion>{
 
 
 template <PatchInit::InitializeableStates State>
-struct InitializeableStatePrint{static constexpr std::string_view name = "<PatchInit::InitializeableState";};
+struct InitializeableStatePrint{};
 
 static inline std::string_view InitializeableStates_to_string(PatchInit::InitializeableStates state)
 {

--- a/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
@@ -11,12 +11,12 @@ class LSIinstructionFromGatesGenerator
 {
 public:
     explicit LSIinstructionFromGatesGenerator(PatchId magic_state_id_start);
-private:
-    PatchId get_next_magic_state_id();
 
     std::queue<LSInstruction> make_t_gate_instructions(PatchId target_id);
     std::queue<LSInstruction> make_cnot_instructions(PatchId source_id, PatchId target_id);
 
+private:
+    PatchId get_next_magic_state_id();
     PatchId magic_state_id_counter_;
 };
 

--- a/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
@@ -1,0 +1,26 @@
+#ifndef LSQECC_LS_INSTRUCTIONS_FROM_GATES_HPP
+#define LSQECC_LS_INSTRUCTIONS_FROM_GATES_HPP
+
+#include <lsqecc/patches/patches.hpp>
+#include <lsqecc/ls_instructions/ls_instructions.hpp>
+
+namespace lsqecc
+{
+
+class LSIinstructionFromGatesGenerator
+{
+public:
+    explicit LSIinstructionFromGatesGenerator(PatchId magic_state_id_start);
+private:
+    PatchId get_next_magic_state_id();
+
+    std::queue<LSInstruction> make_t_gate_instructions(PatchId target_id);
+    std::queue<LSInstruction> make_cnot_instructions(PatchId source_id, PatchId target_id);
+
+    PatchId magic_state_id_counter_;
+};
+
+}
+
+
+#endif //LSQECC_LS_INSTRUCTIONS_FROM_GATES_HPP

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -160,6 +160,21 @@ void queue_extend(std::queue<T>& target, std::queue<T>& source)
     while(!source.empty()) target.push(queue_pop(source));
 }
 
+
+template<class IterableOfStringifiables>
+std::string join(IterableOfStringifiables iterable_of_stringifiables, std::string_view separator)
+{
+    std::string acc;
+    bool begin = true;
+    for(const auto& v: iterable_of_stringifiables)
+    {
+        if(begin) acc = v;
+        else acc = lstk::cat(acc, separator, v);
+        begin = false;
+    }
+    return acc;
+}
+
 }
 
 #define LSTK_THROW(exception_name, args) \

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -153,6 +153,13 @@ T queue_pop(std::queue<T>& queue)
     return v;
 }
 
+// Leaves source empty
+template<class T>
+void queue_extend(std::queue<T>& target, std::queue<T>& source)
+{
+    while(!source.empty()) target.push(queue_pop(source));
+}
+
 }
 
 #define LSTK_THROW(exception_name, args) \

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #define LSTK_UNREACHABLE throw std::logic_error(std::string{"Meant to be unreachable: "}+__FILE__+":"+std::to_string(__LINE__))
+#define LSTK_NOT_IMPLEMENTED throw std::logic_error(std::string{"Not implemented: "}+__FILE__+":"+std::to_string(__LINE__))
 
 namespace lstk
 {
@@ -152,7 +153,9 @@ T queue_pop(std::queue<T>& queue)
     return v;
 }
 
-
 }
+
+#define LSTK_THROW(exception_name, args) \
+throw exception_name{lstk::cat("Exception at ",__FILE__,":",__LINE__,args)}
 
 #endif //LSQECC_LSTK_HPP

--- a/src/gates/gates.cpp
+++ b/src/gates/gates.cpp
@@ -59,7 +59,7 @@ std::vector<gates::Gate> decompose_CRZ_gate(const gates::ControlledGate& crz_gat
 
 std::vector<gates::Gate> to_clifford_plus_t(const gates::Gate& gate)
 {
-    if(const auto* basic_gate = std::get_if<gates::BasicGate>(&gate))
+    if(const auto* basic_gate = std::get_if<gates::BasicSingleQubitGate>(&gate))
         return {*basic_gate};
     else if (const auto* rz_gate = std::get_if<gates::RZ>(&gate))
         throw std::runtime_error{"Not implemented: rz to clifford+T"};

--- a/src/gates/parse_gates.cpp
+++ b/src/gates/parse_gates.cpp
@@ -60,11 +60,17 @@ QubitNum get_index_arg(std::string_view s)
 
 gates::Gate parse_qasm_gate(const Line& line)
 {
-    if(line.instruction == "x") return gates::X(get_index_arg(line.args[0]));
-    if(line.instruction == "z") return gates::Z(get_index_arg(line.args[0]));
-    if(line.instruction == "s") return gates::S(get_index_arg(line.args[0]));
-    if(line.instruction == "t") return gates::T(get_index_arg(line.args[0]));
-    if(line.instruction == "h") return gates::H(get_index_arg(line.args[0]));
+    if(line.instruction == "x") return gates::X(get_index_arg(line.args.at(0)));
+    if(line.instruction == "z") return gates::Z(get_index_arg(line.args.at(0)));
+    if(line.instruction == "s") return gates::S(get_index_arg(line.args.at(0)));
+    if(line.instruction == "t") return gates::T(get_index_arg(line.args.at(0)));
+    if(line.instruction == "h") return gates::H(get_index_arg(line.args.at(0)));
+
+    if(line.instruction == "cx")
+    {
+        if(line.args.size() != 2) throw GateParseException{lstk::cat("cx gate must have 2 args")};
+        return gates::CNOT(get_index_arg(line.args.at(1)), get_index_arg(line.args.at(0)));
+    }
 
     if(line.instruction.substr(0,2) == "rz")
     {

--- a/src/gates/parse_gates.cpp
+++ b/src/gates/parse_gates.cpp
@@ -60,11 +60,11 @@ QubitNum get_index_arg(std::string_view s)
 
 gates::Gate parse_qasm_gate(const Line& line)
 {
-    if(line.instruction == "x") return gates::X(try_parse_int<QubitNum>(line.args[0]));
-    if(line.instruction == "z") return gates::Z(try_parse_int<QubitNum>(line.args[0]));
-    if(line.instruction == "s") return gates::S(try_parse_int<QubitNum>(line.args[0]));
-    if(line.instruction == "t") return gates::T(try_parse_int<QubitNum>(line.args[0]));
-    if(line.instruction == "h") return gates::H(try_parse_int<QubitNum>(line.args[0]));
+    if(line.instruction == "x") return gates::X(get_index_arg(line.args[0]));
+    if(line.instruction == "z") return gates::Z(get_index_arg(line.args[0]));
+    if(line.instruction == "s") return gates::S(get_index_arg(line.args[0]));
+    if(line.instruction == "t") return gates::T(get_index_arg(line.args[0]));
+    if(line.instruction == "h") return gates::H(get_index_arg(line.args[0]));
 
     if(line.instruction.substr(0,2) == "rz")
     {

--- a/src/ls_instructions/ls_instruction_stream.cpp
+++ b/src/ls_instructions/ls_instruction_stream.cpp
@@ -1,4 +1,3 @@
-
 #include <lstk/lstk.hpp>
 
 #include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
@@ -10,7 +9,6 @@
 
 namespace lsqecc {
 using namespace std::string_literals;
-
 
 void LSInstructionStreamFromFile::advance_instruction()
 {
@@ -60,6 +58,8 @@ LSInstruction LSInstructionStreamFromFile::get_next_instruction()
     return instruction;
 }
 
+
+
 LSInstruction LSInstructionStreamFromGateStream::get_next_instruction()
 {
     if(next_instructions_.empty())
@@ -67,7 +67,64 @@ LSInstruction LSInstructionStreamFromGateStream::get_next_instruction()
         if(!gate_stream_.has_next_gate())
             throw std::logic_error{"LSInstructionStreamFromGateStream: No more gates but requesting instructions"};
 
-        // RESUME HERE BREAKING INSTRUCIONS DOWN AND PUSHING THEM TO next_instructions_
+        gates::Gate next_gate = gate_stream_.get_next_gate();
+
+        if(const auto* sq_gate = std::get_if<gates::BasicSingleQubitGate>(&next_gate))
+        {
+            switch(sq_gate->gate_type)
+            {
+#define SINGLE_QUBIT_OP_CASE(Op)\
+                case gates::BasicSingleQubitGate::Type::Op: \
+                    next_instructions_.push({.operation={SingleQubitOp{sq_gate->target_qubit,SingleQubitOp::Operator::Op}}});\
+                    break;
+                SINGLE_QUBIT_OP_CASE(Z)
+                SINGLE_QUBIT_OP_CASE(X)
+                SINGLE_QUBIT_OP_CASE(H)
+                SINGLE_QUBIT_OP_CASE(S)
+#undef SINGLE_QUBIT_OP_CASE
+                case gates::BasicSingleQubitGate::Type::T:
+                    make_t_gate_instructions( sq_gate->target_qubit);
+                    break;
+            }
+        }
+        else if(const auto* rz_gate = std::get_if<gates::RZ>(&next_gate))
+        {
+            if(rz_gate->pi_fraction.num == 1 && rz_gate->pi_fraction.den == 1)
+                next_instructions_.push({.operation={SingleQubitOp{rz_gate->target_qubit,SingleQubitOp::Operator::Z}}});
+            else if(rz_gate->pi_fraction.num == 1 && rz_gate->pi_fraction.den == 2)
+                next_instructions_.push({.operation={SingleQubitOp{rz_gate->target_qubit,SingleQubitOp::Operator::S}}});
+            else if(rz_gate->pi_fraction.num == 1 && rz_gate->pi_fraction.den == 4)
+                make_t_gate_instructions(rz_gate->target_qubit);
+            else
+                throw std::runtime_error(lstk::cat(
+                        "Cannot approximate R_z(",rz_gate->pi_fraction.num,",",rz_gate->pi_fraction.den,")"));
+        }
+        else if(const auto* controlled_gate = std::get_if<gates::ControlledGate>(&next_gate))
+        {
+            if(const auto* target_gate = std::get_if<gates::BasicSingleQubitGate>(&controlled_gate->target_gate))
+            {
+                if(target_gate->gate_type == gates::BasicSingleQubitGate::Type::X)
+                {
+                    LSTK_NOT_IMPLEMENTED;
+                }
+                else if (target_gate->gate_type == gates::BasicSingleQubitGate::Type::Z)
+                {
+                    LSTK_NOT_IMPLEMENTED;
+                }
+                else
+                    throw std::runtime_error{lstk::cat(
+                            "Gate type of index ", static_cast<size_t>(target_gate->gate_type), "Not supported for control")};
+            }
+            else if(const auto* target_gate = std::get_if<gates::BasicSingleQubitGate>(&controlled_gate->target_gate))
+            {
+                LSTK_NOT_IMPLEMENTED;
+            }
+
+        }
+        else
+        {
+            LSTK_UNREACHABLE;
+        }
 
     }
 
@@ -76,16 +133,28 @@ LSInstruction LSInstructionStreamFromGateStream::get_next_instruction()
 
 
 
-LSInstructionStreamFromGateStream::LSInstructionStreamFromGateStream(GateStream& gate_stream)
-: gate_stream_(gate_stream)
+tsl::ordered_set<PatchId> core_qubits_from_gate_stream(GateStream& gate_stream)
 {
-    for(PatchId id = 0; id <gate_stream_.get_qreg().size; id++)
-        core_qubits_.insert(id);
+    tsl::ordered_set<PatchId> core_qubits;
+    for(PatchId id = 0; id <gate_stream.get_qreg().size; id++)
+        core_qubits.insert(id);
+    assert(core_qubits.size());
+    return core_qubits;
 }
+
+
+LSInstructionStreamFromGateStream::LSInstructionStreamFromGateStream(GateStream& gate_stream)
+: gate_stream_(gate_stream),
+  next_instructions_(),
+  core_qubits_(core_qubits_from_gate_stream(gate_stream)),
+  instruction_generator_(*std::max_element(core_qubits_.begin(), core_qubits_.end())+1)
+{
+}
+
 const tsl::ordered_set<PatchId>& LSInstructionStreamFromGateStream::core_qubits() const
 {
     return core_qubits_;
 }
 
-}
 
+}

--- a/src/ls_instructions/ls_instruction_stream.cpp
+++ b/src/ls_instructions/ls_instruction_stream.cpp
@@ -161,5 +161,13 @@ const tsl::ordered_set<PatchId>& LSInstructionStreamFromGateStream::core_qubits(
     return core_qubits_;
 }
 
+std::ostream& print_all_ls_instructions_to_string(std::ostream& os, std::unique_ptr<LSInstructionStream>&& ls_instruction_stream)
+{
+    while(ls_instruction_stream->has_next_instruction())
+        os << ls_instruction_stream->get_next_instruction() << "\n";
+    return os;
+}
+
+
 
 }

--- a/src/ls_instructions/ls_instruction_stream.cpp
+++ b/src/ls_instructions/ls_instruction_stream.cpp
@@ -83,7 +83,8 @@ LSInstruction LSInstructionStreamFromGateStream::get_next_instruction()
                 SINGLE_QUBIT_OP_CASE(S)
 #undef SINGLE_QUBIT_OP_CASE
                 case gates::BasicSingleQubitGate::Type::T:
-                    make_t_gate_instructions( sq_gate->target_qubit);
+                    auto instructions = instruction_generator_.make_t_gate_instructions( sq_gate->target_qubit);
+                    lstk::queue_extend(next_instructions_, instructions);
                     break;
             }
         }
@@ -94,7 +95,11 @@ LSInstruction LSInstructionStreamFromGateStream::get_next_instruction()
             else if(rz_gate->pi_fraction.num == 1 && rz_gate->pi_fraction.den == 2)
                 next_instructions_.push({.operation={SingleQubitOp{rz_gate->target_qubit,SingleQubitOp::Operator::S}}});
             else if(rz_gate->pi_fraction.num == 1 && rz_gate->pi_fraction.den == 4)
-                make_t_gate_instructions(rz_gate->target_qubit);
+            {
+                auto instructions = instruction_generator_.make_t_gate_instructions(rz_gate->target_qubit);
+                lstk::queue_extend(next_instructions_, instructions);
+            }
+
             else
                 throw std::runtime_error(lstk::cat(
                         "Cannot approximate R_z(",rz_gate->pi_fraction.num,",",rz_gate->pi_fraction.den,")"));

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -1,5 +1,6 @@
 #include <lsqecc/ls_instructions/ls_instructions.hpp>
 
+#include <sstream>
 
 
 namespace lsqecc {
@@ -35,8 +36,63 @@ std::vector<PatchId> LSInstruction::get_operating_patches() const
 
 std::ostream& operator<<(std::ostream& os, const LSInstruction& instruction)
 {
+
     return os << "<An LS Instruction>";
 }
 
+std::ostream& operator<<(std::ostream& os, const DeclareLogicalQubitPatches& instruction)
+{
+    return os << LSInstructionPrint<DeclareLogicalQubitPatches>::name
+       << " " << lstk::join(instruction.patch_ids,",");
+}
+
+std::ostream& operator<<(std::ostream& os, const SinglePatchMeasurement& instruction)
+{
+    return os << LSInstructionPrint<SinglePatchMeasurement>::name
+     << " " << instruction.target
+     << " " << (instruction.is_negative ? "-": "") << PauliOperator_to_string(instruction.observable);
+}
+
+std::ostream& operator<<(std::ostream& os, const MultiPatchMeasurement& instruction)
+{
+    os << LSInstructionPrint<MultiPatchMeasurement>::name << " ";
+    if(instruction.is_negative) os << "-";
+
+    for(const auto& [patch_id, local_observable] : instruction.observable)
+        os << patch_id << "," << PauliOperator_to_string(local_observable);
+    return os;
+}
+
+
+std::ostream& operator<<(std::ostream& os, const PatchInit& instruction)
+{
+    return os << LSInstructionPrint<PatchInit>::name
+        << " " << instruction.target << " " << InitializeableStates_to_string(instruction.state);
+}
+
+std::ostream& operator<<(std::ostream& os, const MagicStateRequest& instruction)
+{
+    return os << LSInstructionPrint<MagicStateRequest>::name
+        << " " << instruction.target
+        << " #WaitAtMostFor " << instruction.wait_at_most_for;
+}
+
+std::ostream& operator<<(std::ostream& os, const SingleQubitOp& instruction)
+{
+    return os << SingleQuibitOperatorName_to_string(instruction.op)
+        <<  LSInstructionPrint<SingleQubitOp>::name << " " << instruction.target;
+}
+
+std::ostream& operator<<(std::ostream& os, const RotateSingleCellPatch& instruction)
+{
+    return os << LSInstructionPrint<RotateSingleCellPatch>::name << " " << instruction.target;
+}
+std::ostream& operator<<(std::ostream& os, const BusyRegion& instruction)
+{
+    os << LSInstructionPrint<BusyRegion>::name << " ";
+    for (const auto &cell: instruction.region.cells)
+        os << "OccupiedRegion:" << "(" << cell.cell.row << "," << cell.cell.col << ")";
+    return os << " " << "StateAfterClearing:TODO"; // TODO
+}
 
 }

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -36,8 +36,8 @@ std::vector<PatchId> LSInstruction::get_operating_patches() const
 
 std::ostream& operator<<(std::ostream& os, const LSInstruction& instruction)
 {
-
-    return os << "<An LS Instruction>";
+    std::visit([&os](auto&& op){ os << op;}, instruction.operation);
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const DeclareLogicalQubitPatches& instruction)

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -1,6 +1,7 @@
 #include <lsqecc/ls_instructions/ls_instructions.hpp>
 
 #include <sstream>
+#include <vector>
 
 
 namespace lsqecc {
@@ -58,9 +59,10 @@ std::ostream& operator<<(std::ostream& os, const MultiPatchMeasurement& instruct
     os << LSInstructionPrint<MultiPatchMeasurement>::name << " ";
     if(instruction.is_negative) os << "-";
 
+    std::vector<std::string> op_patch_mapping;
     for(const auto& [patch_id, local_observable] : instruction.observable)
-        os << patch_id << "," << PauliOperator_to_string(local_observable);
-    return os;
+        op_patch_mapping.push_back(lstk::cat(patch_id, ":", PauliOperator_to_string(local_observable));
+    return os << lstk::join(op_patch_mapping,",");
 }
 
 

--- a/src/ls_instructions/ls_instructions_from_gates.cpp
+++ b/src/ls_instructions/ls_instructions_from_gates.cpp
@@ -1,0 +1,33 @@
+#include <lsqecc/ls_instructions/ls_instructions_from_gates.hpp>
+
+namespace lsqecc
+{
+
+
+LSIinstructionFromGatesGenerator::LSIinstructionFromGatesGenerator(PatchId magic_state_id_start)
+: magic_state_id_counter_(magic_state_id_start)
+{}
+
+PatchId LSIinstructionFromGatesGenerator::get_next_magic_state_id()
+{
+    return magic_state_id_counter_++;
+}
+
+std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_t_gate_instructions(PatchId target_id)
+{
+    std::queue<LSInstruction> next_instructions;
+    PatchId new_magic_state_id = get_next_magic_state_id();
+    next_instructions.push({.operation={MagicStateRequest{new_magic_state_id, MagicStateRequest::DEFAULT_WAIT}}});
+    next_instructions.push({.operation={
+            MultiPatchMeasurement{.observable={
+                    {target_id,PauliOperator::Z},
+                    {new_magic_state_id,PauliOperator::Z},
+            },.is_negative=false}}});
+    next_instructions.push({.operation={SinglePatchMeasurement{
+            new_magic_state_id, PauliOperator::X, false
+    }}});
+    next_instructions.push({.operation={SingleQubitOp{target_id, SingleQubitOp::Operator::S}}});
+    return next_instructions;
+}
+
+}

--- a/src/ls_instructions/ls_instructions_from_gates.cpp
+++ b/src/ls_instructions/ls_instructions_from_gates.cpp
@@ -15,7 +15,7 @@ PatchId LSIinstructionFromGatesGenerator::get_next_magic_state_id()
 
 std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_t_gate_instructions(PatchId target_id)
 {
-    std::queue<LSInstruction> next_instructions;
+    std::queue<LSInstruction>   next_instructions;
     PatchId new_magic_state_id = get_next_magic_state_id();
     next_instructions.push({.operation={MagicStateRequest{new_magic_state_id, MagicStateRequest::DEFAULT_WAIT}}});
     next_instructions.push({.operation={

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -95,7 +95,12 @@ namespace lsqecc
                 .required(false);
         parser.add_argument()
                 .names({"--graceful"})
-                .description("If there is an error when slicing, print the error and terminate");
+                .description("If there is an error when slicing, print the error and terminate")
+                .required(false);
+        parser.add_argument()
+                .names({"--lli"})
+                .description("Output LLI instead of JSONs")
+                .required(false);
         parser.enable_help();
 
         auto err = parser.parse(argc, argv);
@@ -110,7 +115,6 @@ namespace lsqecc
             parser.print_help();
             return 0;
         }
-
 
         std::reference_wrapper<std::ostream> write_slices_stream = std::ref(std::cout);
         std::unique_ptr<std::ostream> _ofstream_store;
@@ -161,7 +165,7 @@ namespace lsqecc
             instruction_stream = std::make_unique<LSInstructionStreamFromFile>(file_stream);
         }
         if(!instruction_stream)
-            instruction_stream = std::make_unique<LSInstructionStreamFromFile>(std::cin);
+            instruction_stream = std::make_unique<LSInstructionStreamFromFile>(in_stream);
 
 
         std::unique_ptr<GateStream> gate_stream;
@@ -177,6 +181,11 @@ namespace lsqecc
             instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream);
         }
 
+        if(parser.exists("lli"))
+        {
+            print_all_ls_instructions_to_string(out_stream, std::move(instruction_stream));
+            return 0;
+        }
 
         std::unique_ptr<Layout> layout;
         if(parser.exists("l"))

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -61,7 +61,7 @@ namespace lsqecc
                 .description("File name of file with LS Instructions. If not provided will read LS Instructions from stdin")
                 .required(false);
         parser.add_argument()
-                .names({"-q", "--qasm"})
+                .names({"-q", "--qasm"}) // TODO remove and use extension
                 .description("File name of file with QASM. If not provided will read LS Instructions (not QASM) from stdin")
                 .required(false);
         parser.add_argument()
@@ -169,11 +169,12 @@ namespace lsqecc
         {
             file_stream = std::ifstream(parser.get<std::string>("q"));
             if(file_stream.fail()){
-                err_stream << "Could not open instruction file: " << parser.get<std::string>("q") <<std::endl;
+                err_stream << "Could not open instruc`tion file: " << parser.get<std::string>("q") <<std::endl;
                 return -1;
             }
 
             gate_stream = std::make_unique<GateStreamFromFile>(file_stream);
+            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream);
         }
 
 

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -157,14 +157,14 @@ namespace lsqecc
             }
 
             file_stream = std::ifstream(parser.get<std::string>("i"));
-            if(file_stream.fail()){
+            if(file_stream.fail() || !std::filesystem::exists(parser.get<std::string>("i"))){
                 err_stream << "Could not open instruction file: " << parser.get<std::string>("i") <<std::endl;
                 return -1;
             }
 
             instruction_stream = std::make_unique<LSInstructionStreamFromFile>(file_stream);
         }
-        if(!instruction_stream)
+        if(!instruction_stream && !parser.exists("q"))
             instruction_stream = std::make_unique<LSInstructionStreamFromFile>(in_stream);
 
 
@@ -172,8 +172,8 @@ namespace lsqecc
         if(parser.exists("q"))
         {
             file_stream = std::ifstream(parser.get<std::string>("q"));
-            if(file_stream.fail()){
-                err_stream << "Could not open instruc`tion file: " << parser.get<std::string>("q") <<std::endl;
+            if(file_stream.fail() || !std::filesystem::exists(parser.get<std::string>("q"))){
+                err_stream << "Could not open instruction file: " << parser.get<std::string>("q") <<std::endl;
                 return -1;
             }
 


### PR DESCRIPTION
Parsing in general has been in the works for a while. Shifted focus to a smaller subset so that we can move forward quicker. Also sets up structure to add more gates later if needed.

1. Adds parsing of `h`,`x`,`z`,`s`,`t`,`cx`,`cz`,`crz`.
2. Implements LLI generation for `h`,`x`,`z`,`s`,`t`. Magic state distillation needs to be polished.
3. Implements full LLI printing

Need to complete LLI generation to make the gate set complete. Will do as part of:
 - https://github.com/latticesurgery-com/liblsqecc/issues/20
 
Does not implement SK decompositions yet. Worth mentioning that we can integrate with Gridsynth at a binary level if we decide we want that. Can leave conditional with a build flag so it doesn't compromise portability.

CC @alexandrupaler, @alexandrupaler, @isolatedinformation 