### PR TITLE
Add corrective terms to CNOTs

### DIFF
--- a/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
+++ b/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
@@ -48,7 +48,7 @@ private:
 
 class LSInstructionStreamFromGateStream : public LSInstructionStream {
 public:
-    explicit LSInstructionStreamFromGateStream(GateStream& gate_stream);
+    LSInstructionStreamFromGateStream(GateStream& gate_stream, CNOTCorrectionMode cnot_correction_mode);
 
     LSInstruction get_next_instruction() override;
     bool has_next_instruction() const override {return next_instructions_.size() || gate_stream_.has_next_gate();};
@@ -60,7 +60,7 @@ private:
     std::queue<LSInstruction> next_instructions_;
     tsl::ordered_set<PatchId> core_qubits_;
     LSIinstructionFromGatesGenerator instruction_generator_;
-    size_t line_number_ = 0;
+    CNOTCorrectionMode cnot_correction_mode_;
 };
 
 

--- a/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
@@ -8,6 +8,11 @@
 namespace lsqecc
 {
 
+enum class CNOTCorrectionMode {
+    NEVER,
+    ALWAYS
+    // TODO add RANDOMIZED
+};
 
 class LSIinstructionFromGatesGenerator
 {
@@ -16,7 +21,11 @@ public:
 
     std::queue<LSInstruction> make_t_gate_instructions(PatchId target_id);
     std::queue<LSInstruction> make_cnot_instructions(
-            PatchId control_id, PatchId target_id, gates::CNOTType cnot_type, gates::CNOTAncillaPlacement cnot_ancilla_placement);
+            PatchId control_id,
+            PatchId target_id,
+            gates::CNOTType cnot_type,
+            gates::CNOTAncillaPlacement cnot_ancilla_placement,
+            CNOTCorrectionMode cnot_correction_mode);
 
 private:
     PatchId get_next_ancilla_state_id();

--- a/src/ls_instructions/ls_instruction_stream.cpp
+++ b/src/ls_instructions/ls_instruction_stream.cpp
@@ -110,7 +110,11 @@ LSInstruction LSInstructionStreamFromGateStream::get_next_instruction()
                 if(target_gate->gate_type == gates::BasicSingleQubitGate::Type::X)
                 {
                     auto instructions = instruction_generator_.make_cnot_instructions(
-                            controlled_gate->control_qubit, target_gate->target_qubit, controlled_gate->cnot_type, controlled_gate->cnot_ancilla_placement);
+                            controlled_gate->control_qubit,
+                            target_gate->target_qubit,
+                            controlled_gate->cnot_type,
+                            controlled_gate->cnot_ancilla_placement,
+                            cnot_correction_mode_);
                     lstk::queue_extend(next_instructions_, instructions);
                 }
                 else if (target_gate->gate_type == gates::BasicSingleQubitGate::Type::Z)
@@ -150,11 +154,12 @@ tsl::ordered_set<PatchId> core_qubits_from_gate_stream(GateStream& gate_stream)
 }
 
 
-LSInstructionStreamFromGateStream::LSInstructionStreamFromGateStream(GateStream& gate_stream)
+LSInstructionStreamFromGateStream::LSInstructionStreamFromGateStream(GateStream& gate_stream, CNOTCorrectionMode cnot_correction_mode)
 : gate_stream_(gate_stream),
   next_instructions_(),
   core_qubits_(core_qubits_from_gate_stream(gate_stream)),
-  instruction_generator_(*std::max_element(core_qubits_.begin(), core_qubits_.end())+1)
+  instruction_generator_(*std::max_element(core_qubits_.begin(), core_qubits_.end())+1),
+  cnot_correction_mode_(cnot_correction_mode)
 {
 }
 

--- a/src/ls_instructions/ls_instructions_from_gates.cpp
+++ b/src/ls_instructions/ls_instructions_from_gates.cpp
@@ -31,7 +31,11 @@ std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_t_gate_instruct
 }
 
 std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_cnot_instructions(
-        PatchId control_id, PatchId target_id, gates::CNOTType cnot_type, gates::CNOTAncillaPlacement cnot_ancilla_placement)
+        PatchId control_id,
+        PatchId target_id,
+        gates::CNOTType cnot_type,
+        gates::CNOTAncillaPlacement cnot_ancilla_placement,
+        CNOTCorrectionMode cnot_correction_mode)
 {
     // Control is green -> smooth -> measures X otimes X
     // Target is red -> rough -> measures Z otimes Z
@@ -53,11 +57,19 @@ std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_cnot_instructio
                         {control_id, PauliOperator::X},
                         {ancilla_id, PauliOperator::X},
                 },.is_negative=false}}});
+        if(cnot_correction_mode == CNOTCorrectionMode::ALWAYS)
+            next_instructions.push({.operation={
+                    SingleQubitOp{ancilla_id, SingleQubitOp::Operator::X}
+            }});
         next_instructions.push({.operation={
                 MultiPatchMeasurement{.observable={
                         {ancilla_id,PauliOperator::Z},
                         {target_id,PauliOperator::Z},
                 },.is_negative=false}}});
+        if(cnot_correction_mode == CNOTCorrectionMode::ALWAYS)
+            next_instructions.push({.operation={
+                    SingleQubitOp{control_id, SingleQubitOp::Operator::Z}
+            }});
     }
     else if(cnot_type == gates::CNOTType::ZX_WITH_MBM_TARGET_FIRST){
         next_instructions.push({.operation={
@@ -65,11 +77,19 @@ std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_cnot_instructio
                         {ancilla_id,PauliOperator::Z},
                         {target_id,PauliOperator::Z},
                 },.is_negative=false}}});
+        if(cnot_correction_mode == CNOTCorrectionMode::ALWAYS)
+            next_instructions.push({.operation={
+                    SingleQubitOp{ancilla_id, SingleQubitOp::Operator::Z}
+            }});
         next_instructions.push({.operation={
                 MultiPatchMeasurement{.observable={
                         {control_id, PauliOperator::X},
                         {ancilla_id, PauliOperator::X},
                 },.is_negative=false}}});
+        if(cnot_correction_mode == CNOTCorrectionMode::ALWAYS)
+            next_instructions.push({.operation={
+                    SingleQubitOp{target_id, SingleQubitOp::Operator::X}
+            }});
     }
     else LSTK_UNREACHABLE;
 

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -101,6 +101,10 @@ namespace lsqecc
                 .names({"--lli"})
                 .description("Output LLI instead of JSONs")
                 .required(false);
+        parser.add_argument()
+                .names({"--cnotcorrections"})
+                .description("Add Xs and Zs to correct the the negative outcomes: never (default), always") // TODO add random
+                .required(false);
         parser.enable_help();
 
         auto err = parser.parse(argc, argv);
@@ -178,7 +182,21 @@ namespace lsqecc
             }
 
             gate_stream = std::make_unique<GateStreamFromFile>(file_stream);
-            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream);
+
+            CNOTCorrectionMode cnot_correction_mode = CNOTCorrectionMode::NEVER;
+            if(parser.exists("cnotcorrections"))
+            {
+                if(parser.get<std::string>("cnotcorrections") == "always")
+                    cnot_correction_mode = CNOTCorrectionMode::ALWAYS;
+                else if(parser.get<std::string>("cnotcorrections") == "never")
+                    cnot_correction_mode = CNOTCorrectionMode::NEVER;
+                else
+                {
+                    err_stream << "Unknown CNOT correction mode: " << parser.get<std::string>("cnotcorrections") <<std::endl;
+                    return -1;
+                }
+            }
+            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream, cnot_correction_mode);
         }
 
         if(parser.exists("lli"))


### PR DESCRIPTION
closes #20

Adds the `--cnotcorrections` to add corrective terms (in worst case estimate - always on) to the computation, based on the scheme below:

![File](https://user-images.githubusercontent.com/36427091/189541579-e639e541-6de7-4c3a-a03c-fee22a6750c8.jpg)
