### PR TITLE
Basic Compact Layout functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ add_library(
         src/gates/gates.cpp
         src/patches/dense_slice.cpp
         src/patches/dense_patch_computation.cpp
-        src/ls_instructions/ls_instructions_from_gates.cpp)
+        src/ls_instructions/ls_instructions_from_gates.cpp src/layout/dynamic_layouts/compact_layout.cpp)
 
 set(LSQECCLIB_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,24 +48,28 @@ include_directories(external/include)
 add_library(
         lsqecclib
         src/gates/parse_gates.cpp
-        src/patches/sparse_patch_computation.cpp
-        src/ls_instructions/ls_instructions.cpp
-        src/ls_instructions/ls_instructions_parse.cpp
-        src/ls_instructions/ls_instruction_stream.cpp
-        src/ls_instructions/parse_utils.cpp
+        src/gates/gates.cpp
+        src/patches/dense_slice.cpp
+        src/patches/dense_patch_computation.cpp
         src/patches/patches.cpp
         src/patches/sparse_slice.cpp
         src/patches/slices_to_json.cpp
+        src/patches/sparse_patch_computation.cpp
+        src/pipelines/slicer.cpp
+        src/layout/dynamic_layouts/compact_layout.cpp
+        src/layout/dynamic_layouts/determine_exposed_operators.cpp
         src/layout/graph_search/boost_based_graph_search.cpp
         src/layout/graph_search/custom_graph_search.cpp
         src/layout/router.cpp
         src/layout/ascii_layout_spec.cpp
         src/layout/layout.cpp
-        src/pipelines/slicer.cpp
-        src/gates/gates.cpp
-        src/patches/dense_slice.cpp
-        src/patches/dense_patch_computation.cpp
-        src/ls_instructions/ls_instructions_from_gates.cpp src/layout/dynamic_layouts/compact_layout.cpp)
+        src/ls_instructions/boundary_rotation_injection_stream.cpp
+        src/ls_instructions/ls_instructions_from_gates.cpp
+        src/ls_instructions/ls_instructions_parse.cpp
+        src/ls_instructions/ls_instruction_stream.cpp
+        src/ls_instructions/ls_instructions.cpp
+        src/ls_instructions/parse_utils.cpp
+       )
 
 set(LSQECCLIB_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Liblsqecc
 
-A collection of C++ tools to speed up the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler).
+Home of a set of fast tools for compiling lattice surgery instructions. Part of the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler) family.
+
+![](https://user-images.githubusercontent.com/36427091/193476068-eddfea28-3d91-4398-8de4-3a55bb43faa7.gif)
 
 ## Targets
 ### The `lsqecc_slicer` executable
@@ -10,7 +12,11 @@ Found at the top level of the build directory. Produces [latticesurgery.com](htt
 Example usage: 
 
 ```shell
+# Basic example of using LLI instructions generated from LSC
 lsqecc_slicer -i instructions.txt -l 10_by_10_layout.txt -o output.json
+
+# Litinski's compact layout
+lsqecc_slicer -q examples/qasm/compact_layout_demo.qasm -o out.json --compactlayout --graceful
 ```
 Where:
  * `instructions.txt` contains [LS Instructions](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/246)
@@ -19,20 +25,22 @@ Where:
 
 Full usage:
 ```
-Usage: cmake-build-debug/lsqecc_slicer [options...]
+Usage: lsqecc_slicer [options...]
 Options:
     -i, --instructions     File name of file with LS Instructions. If not provided will read LS Instructions from stdin
-    -q, --qasm             File name of file with OpenQASM--. If not provided will read LS Instructions from stdin
+    -q, --qasm             File name of file with QASM. If not provided will read LS Instructions (not QASM) from stdin
     -l, --layout           File name of file with layout spec. Defaults to simple layout if none is provided
     -o, --output           File name of output file to which write a latticesurgery.com JSON of the slices. By default outputs to stdout
     -f, --output-format    Requires, STDOUT output format: slices (default), progress , noprogress, machine,
     -t, --timeout          Set a timeout in seconds after which stop producing slices
     -r, --router           Set a router: graph_search (default), graph_search_cached
-    -g, --graph-search     Set a graph search provider: custom (default), boost (not allways available)
+    -g, --graph-search     Set a graph search provider: custom (default), boost (not always available)
     -a, --slice-repr       Set how slices are represented: dense (default), sparse
     --graceful             If there is an error when slicing, print the error and terminate
     --lli                  Output LLI instead of JSONs
-    -h, --help             Shows this page   
+    --cnotcorrections      Add Xs and Zs to correct the the negative outcomes: never (default), always
+    --compactlayout        Uses Litinski's compact layout, incompatible with -l
+    -h, --help             Shows this page 
 ```
 #### QASM Support (Highly experimental)
 LibLSQECC can parse a small subset of OpenQASM 2.0 instead of LLI, with restrictions below. We call this type of assembly OpenQASM--. In general OpenQASM-- should be valid OpenQASM, up to implementation defects. The rules are 
@@ -47,7 +55,7 @@ LibLSQECC can parse a small subset of OpenQASM 2.0 instead of LLI, with restrict
 
 ### The `liblsqecc` library
 
-Contains the functionality used by the `lsqecc_slicer` executable. One day we hope to expose it's functionality as a Python API in the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler) package.
+Contains the functionality used by the `lsqecc_slicer` executable. We are working on exposing its functionality as a Python API in the [Lattice Surgery Compiler](https://github.com/latticesurgery-com/lattice-surgery-compiler) package.
 
 ### Build
 Clone:
@@ -65,6 +73,3 @@ $ cmake ..
 ```
 
 The `lsqecc_slicer` executable will be at the top level of the `build` directory.
-
-
-###

--- a/examples/qasm/ZXCNOTDemo.qasm
+++ b/examples/qasm/ZXCNOTDemo.qasm
@@ -1,0 +1,9 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[15];
+
+cx q[0],q[10]; // %ZXWithMBMControlFirst,AncillaNextToControl
+cx q[0],q[4]; // %ZXWithMBMControlFirst,AncillaNextToTarget
+cx q[0],q[12]; // %ZXWithMBMTargetFirst,AncillaNextToControl
+cx q[0],q[14]; // %ZXWithMBMTargetFirst,AncillaNextToTarget

--- a/examples/qasm/ZXCNOTDemo.qasm
+++ b/examples/qasm/ZXCNOTDemo.qasm
@@ -3,7 +3,7 @@ include "qelib1.inc";
 
 qreg q[15];
 
-cx q[0],q[10]; // %ZXWithMBMControlFirst,AncillaNextToControl
-cx q[0],q[4]; // %ZXWithMBMControlFirst,AncillaNextToTarget
-cx q[0],q[12]; // %ZXWithMBMTargetFirst,AncillaNextToControl
-cx q[0],q[14]; // %ZXWithMBMTargetFirst,AncillaNextToTarget
+cx q[0],q[10]; // %ZXWithMBMControlFirst,AncillaFreePlacement
+cx q[0],q[4]; // %ZXWithMBMControlFirst,AncillaFreePlacement
+cx q[0],q[12]; // %ZXWithMBMTargetFirst,AncillaFreePlacement
+cx q[0],q[14]; // %ZXWithMBMTargetFirst,AncillaFreePlacement

--- a/examples/qasm/compact_layout_demo.qasm
+++ b/examples/qasm/compact_layout_demo.qasm
@@ -1,0 +1,9 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[15];
+
+cx q[0],q[10];
+cx q[1],q[3];
+cx q[5],q[7];
+t q[2];

--- a/examples/qasm/compact_layout_demo.qasm
+++ b/examples/qasm/compact_layout_demo.qasm
@@ -4,6 +4,7 @@ include "qelib1.inc";
 qreg q[15];
 
 cx q[0],q[10];
+s q[1];
 cx q[1],q[3];
 cx q[5],q[7];
-t q[2];
+t q[2];s

--- a/examples/qasm/end_to_end.qasm
+++ b/examples/qasm/end_to_end.qasm
@@ -1,0 +1,18 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[8];
+
+h q[1];
+h q[2];
+s q[3];
+s q[4];
+x q[5];
+s q[6];
+cx q[0],q[7];
+cx q[0],q[7]; // %ZXWithMBMControlFirst
+cx q[0],q[7]; // %ZXWithMBMTargetFirst
+cx q[0],q[7]; // %ZXWithMBMControlFirst,AncillaNextToControl
+cx q[0],q[7]; // %ZXWithMBMControlFirst,AncillaNextToTarget
+cx q[0],q[7]; // %ZXWithMBMTargetFirst,AncillaNextToControl
+cx q[0],q[7]; // %ZXWithMBMTargetFirst,AncillaNextToTarget

--- a/include/lsqecc/layout/ascii_layout_spec.hpp
+++ b/include/lsqecc/layout/ascii_layout_spec.hpp
@@ -18,6 +18,7 @@ public:
         RoutingAncilla = 'r',
         LogicalComputationQubit_StandardBorderOrientation = 'Q',
         LogicalComputationQubit_RotatedBorderOrientation = 'T',
+        LogicalComputationQubit_DynamicAllocation = 'D',
         AncillaQubitLocation = 'A',
         DistillationRegion_0 = '0',
         DistillationRegion_1 = '1',
@@ -50,6 +51,8 @@ public:
         {
         case 'r':
         case 'Q':
+        case 'T':
+        case 'D':
         case 'A':
         case '0':
         case '1':
@@ -67,12 +70,18 @@ public:
         }
     }
 
-    using CellGrid = std::vector<std::vector<AsciiLayoutSpec::CellType>> ;
+    using CellRow = std::vector<AsciiLayoutSpec::CellType> ;
+    using CellGrid = std::vector<CellRow> ;
     static CellGrid parse_grid(const std::string_view input);
 
     explicit AsciiLayoutSpec(const std::string_view input)
     : grid_spec_(parse_grid(input))
     {}
+
+    explicit AsciiLayoutSpec(const CellGrid& grid_spec)
+            : grid_spec_(grid_spec)
+    {}
+
 
     std::optional<Cell> find_a_cell_of_type(AsciiLayoutSpec::CellType target) const;
     std::vector<Cell> find_all_cells_of_type(AsciiLayoutSpec::CellType target) const;
@@ -91,9 +100,14 @@ private:
 class LayoutFromSpec : public Layout{
 public:
 
-    LayoutFromSpec(const std::string_view spec_text)
+    explicit LayoutFromSpec(const std::string_view spec_text)
     {
         init_cache(AsciiLayoutSpec{spec_text});
+    }
+
+    explicit LayoutFromSpec(const AsciiLayoutSpec::CellGrid& grid_spec)
+    {
+        init_cache(AsciiLayoutSpec{grid_spec});
     }
 
 

--- a/include/lsqecc/layout/dynamic_layouts/compact_layout.hpp
+++ b/include/lsqecc/layout/dynamic_layouts/compact_layout.hpp
@@ -1,0 +1,25 @@
+#ifndef LSQECC_COMPACT_LAYOUT_HPP
+#define LSQECC_COMPACT_LAYOUT_HPP
+
+#include <lsqecc/layout/ascii_layout_spec.hpp>
+
+
+
+namespace lsqecc
+{
+
+
+/**
+ * Allocates a layout like so:
+ *
+ * QQQQ ... QrAr11111
+ * rrrr ... rrrr11111
+ * QQQQ ... QrAr11111
+ */
+
+std::unique_ptr<Layout> make_compact_layout(size_t num_core_qubits);
+
+
+} // namespace lsqecc
+
+#endif //LSQECC_COMPACT_LAYOUT_HPP

--- a/include/lsqecc/layout/dynamic_layouts/compact_layout.hpp
+++ b/include/lsqecc/layout/dynamic_layouts/compact_layout.hpp
@@ -1,6 +1,7 @@
 #ifndef LSQECC_COMPACT_LAYOUT_HPP
 #define LSQECC_COMPACT_LAYOUT_HPP
 
+#include <memory>
 #include <lsqecc/layout/ascii_layout_spec.hpp>
 
 

--- a/include/lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp
+++ b/include/lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp
@@ -6,6 +6,7 @@
 #include <lsqecc/patches/slice.hpp>
 #include <lsqecc/layout/layout.hpp>
 #include <tsl/ordered_map.h>
+#include <tsl/ordered_set.h>
 
 namespace lsqecc
 {
@@ -19,9 +20,11 @@ struct RotatableSingleQubitPatchExposedOperators
     void rotate();
 };
 
-tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> determine_exposed_core_operators(const Layout& layout);
+tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> determine_exposed_core_operators(
+        const Layout& layout, const tsl::ordered_set<PatchId>& core_qubit_ids);
 
-RotatableSingleQubitPatchExposedOperators determine_operators_exposed_for_patch(const SparsePatch& patch, const Slice& slice);
+RotatableSingleQubitPatchExposedOperators determine_operators_exposed_for_patch(
+        const SparsePatch& patch, const Slice& slice);
 
 }
 

--- a/include/lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp
+++ b/include/lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp
@@ -1,0 +1,28 @@
+#ifndef LSQECC_DETERMINE_EXPOSED_OPERATORS_HPP
+#define LSQECC_DETERMINE_EXPOSED_OPERATORS_HPP
+
+#include <lsqecc/pauli_rotations/pauli_operator.hpp>
+#include <lsqecc/patches/patches.hpp>
+#include <lsqecc/patches/slice.hpp>
+#include <lsqecc/layout/layout.hpp>
+#include <tsl/ordered_map.h>
+
+namespace lsqecc
+{
+
+struct RotatableSingleQubitPatchExposedOperators
+{
+    bool x_exposed;
+    bool z_exposed;
+
+    bool is_exposed(const PauliOperator op) const;
+    void rotate();
+};
+
+tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> determine_exposed_core_operators(const Layout& layout);
+
+RotatableSingleQubitPatchExposedOperators determine_operators_exposed_for_patch(const SparsePatch& patch, const Slice& slice);
+
+}
+
+#endif //LSQECC_DETERMINE_EXPOSED_OPERATORS_HPP

--- a/include/lsqecc/layout/layout.hpp
+++ b/include/lsqecc/layout/layout.hpp
@@ -43,7 +43,7 @@ namespace LayoutHelpers{
 
 }
 
-
+// Plan to deprecate in favour of compact or fast layouts
 class SimpleLayout : public Layout {
 public:
 

--- a/include/lsqecc/ls_instructions/boundary_rotation_injection_stream.hpp
+++ b/include/lsqecc/ls_instructions/boundary_rotation_injection_stream.hpp
@@ -1,0 +1,34 @@
+#ifndef LSQECC_BOUNDARY_ROTATION_INJECTION_STREAM_HPP
+#define LSQECC_BOUNDARY_ROTATION_INJECTION_STREAM_HPP
+
+#include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
+#include <lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp>
+
+namespace lsqecc
+{
+
+class BoundaryRotationInjectionStream : public LSInstructionStream
+{
+public:
+    BoundaryRotationInjectionStream(std::unique_ptr<LSInstructionStream>&& source, const Layout& layout);
+
+    BoundaryRotationInjectionStream(
+            std::unique_ptr<LSInstructionStream>&& source,
+            tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators>&& starting_exposed_operators);
+
+    LSInstruction get_next_instruction() override;
+
+    bool has_next_instruction() const override;
+
+    const tsl::ordered_set<PatchId> &core_qubits() const override;
+
+private:
+
+    std::unique_ptr<LSInstructionStream> source_;
+    std::queue<LSInstruction> next_instructions_;
+    tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> exposed_operators_;
+};
+
+}
+
+#endif //LSQECC_BOUNDARY_ROTATION_INJECTION_STREAM_HPP

--- a/include/lsqecc/ls_instructions/id_generator.hpp
+++ b/include/lsqecc/ls_instructions/id_generator.hpp
@@ -1,0 +1,33 @@
+#ifndef LSQECC_ID_GENERATOR_HPP
+#define LSQECC_ID_GENERATOR_HPP
+
+#include <lsqecc/patches/patches.hpp>
+
+namespace lsqecc
+{
+
+class IdGenerator
+{
+public:
+
+    void set_start(PatchId start)
+    {
+        counter_ = start;
+    }
+
+    PatchId new_id()
+    {
+        return counter_++;
+    }
+
+    [[nodiscard]] PatchId last_given_id() const
+    {
+        return counter_;
+    }
+private:
+    PatchId counter_ = 0;
+};
+
+}
+
+#endif //LSQECC_ID_GENERATOR_HPP

--- a/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
+++ b/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
@@ -3,6 +3,7 @@
 
 #include <lsqecc/ls_instructions/ls_instructions.hpp>
 #include <lsqecc/ls_instructions/ls_instructions_from_gates.hpp>
+#include <lsqecc/ls_instructions/id_generator.hpp>
 #include <lsqecc/gates/parse_gates.hpp>
 
 
@@ -48,7 +49,11 @@ private:
 
 class LSInstructionStreamFromGateStream : public LSInstructionStream {
 public:
-    LSInstructionStreamFromGateStream(GateStream& gate_stream, CNOTCorrectionMode cnot_correction_mode);
+    LSInstructionStreamFromGateStream(
+            GateStream& gate_stream, // TODO why is this not rvalue ref?
+            CNOTCorrectionMode cnot_correction_mode,
+            IdGenerator& id_generator
+            );
 
     LSInstruction get_next_instruction() override;
     bool has_next_instruction() const override {return next_instructions_.size() || gate_stream_.has_next_gate();};

--- a/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
+++ b/include/lsqecc/ls_instructions/ls_instruction_stream.hpp
@@ -17,6 +17,8 @@
 
 namespace lsqecc {
 
+
+
 class LSInstructionStream
 {
 public:

--- a/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions_from_gates.hpp
@@ -4,6 +4,7 @@
 #include <lsqecc/patches/patches.hpp>
 #include <lsqecc/gates/gates.hpp>
 #include <lsqecc/ls_instructions/ls_instructions.hpp>
+#include <lsqecc/ls_instructions/id_generator.hpp>
 
 namespace lsqecc
 {
@@ -17,7 +18,7 @@ enum class CNOTCorrectionMode {
 class LSIinstructionFromGatesGenerator
 {
 public:
-    explicit LSIinstructionFromGatesGenerator(PatchId ancilla_state_id_start);
+    explicit LSIinstructionFromGatesGenerator(IdGenerator& id_generator);
 
     std::queue<LSInstruction> make_t_gate_instructions(PatchId target_id);
     std::queue<LSInstruction> make_cnot_instructions(
@@ -28,8 +29,7 @@ public:
             CNOTCorrectionMode cnot_correction_mode);
 
 private:
-    PatchId get_next_ancilla_state_id();
-    PatchId ancilla_state_id_counter_;
+    IdGenerator& id_generator_;
 };
 
 }

--- a/include/lsqecc/ls_instructions/teleported_s_gate_injection_stream.hpp
+++ b/include/lsqecc/ls_instructions/teleported_s_gate_injection_stream.hpp
@@ -1,0 +1,34 @@
+#ifndef LSQECC_TELEPORTED_S_GATE_INJECTION_STREAM_HPP
+#define LSQECC_TELEPORTED_S_GATE_INJECTION_STREAM_HPP
+
+#include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
+#include <lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp>
+
+namespace lsqecc
+{
+
+// TODO InjectionStream -> LLIPass
+class TeleportedSGateInjectionStream : public LSInstructionStream
+{
+public:
+    TeleportedSGateInjectionStream(
+            std::unique_ptr<LSInstructionStream>&& source,
+            IdGenerator& id_generator
+            );
+
+    LSInstruction get_next_instruction() override;
+
+    bool has_next_instruction() const override;
+
+    const tsl::ordered_set<PatchId> &core_qubits() const override;
+
+private:
+
+    std::unique_ptr<LSInstructionStream> source_;
+    std::queue<LSInstruction> next_instructions_;
+    IdGenerator& id_generator_;
+};
+
+}
+
+#endif //LSQECC_TELEPORTED_S_GATE_INJECTION_STREAM_HPP

--- a/include/lsqecc/patches/dense_patch_computation.hpp
+++ b/include/lsqecc/patches/dense_patch_computation.hpp
@@ -38,8 +38,7 @@ DensePatchComputationResult run_through_dense_slices(
         Router& router,
         std::optional<std::chrono::seconds> timeout,
         const DenseSliceVisitor& slice_visitor,
-        bool graceful,
-        std::ostream& log);
+        bool graceful);
 
 }
 

--- a/include/lsqecc/patches/dense_patch_computation.hpp
+++ b/include/lsqecc/patches/dense_patch_computation.hpp
@@ -38,7 +38,8 @@ DensePatchComputationResult run_through_dense_slices(
         Router& router,
         std::optional<std::chrono::seconds> timeout,
         const DenseSliceVisitor& slice_visitor,
-        bool graceful);
+        bool graceful,
+        std::ostream& log);
 
 }
 

--- a/include/lsqecc/patches/dense_slice.hpp
+++ b/include/lsqecc/patches/dense_slice.hpp
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <unordered_map>
+#include <tsl/ordered_set.h>
 
 namespace lsqecc
 {
@@ -24,6 +25,7 @@ struct DenseSlice : public Slice
     std::reference_wrapper<const Layout> layout;
 
     explicit DenseSlice(const Layout& layout);
+    DenseSlice(const Layout& layout, const tsl::ordered_set<PatchId>& core_qubit_ids);
 
     virtual const Layout& get_layout() const override;
 
@@ -36,6 +38,7 @@ struct DenseSlice : public Slice
 
     std::optional<std::reference_wrapper<DensePatch>> get_patch_by_id(PatchId id);
     std::optional<std::reference_wrapper<const DensePatch>> get_patch_by_id(PatchId id) const;
+    std::optional<SparsePatch> get_sparse_patch_by_id(PatchId id) const;
     std::optional<Cell> get_cell_by_id(PatchId id) const override;
     bool has_patch(PatchId id) const override;
     std::optional<DensePatch>& patch_at(const Cell& cell);

--- a/src/layout/ascii_layout_spec.cpp
+++ b/src/layout/ascii_layout_spec.cpp
@@ -13,9 +13,11 @@
 #include <deque>
 
 namespace lsqecc{
-std::vector<std::vector<AsciiLayoutSpec::CellType>> AsciiLayoutSpec::parse_grid(const std::string_view input)
+
+
+AsciiLayoutSpec::CellGrid AsciiLayoutSpec::parse_grid(const std::string_view input)
 {
-    std::vector<std::vector<AsciiLayoutSpec::CellType>> rows;
+    AsciiLayoutSpec::CellGrid rows;
     for(const std::string_view& row: lstk::split_on(input,'\n'))
     {
         if(row.length() == 0) continue;

--- a/src/layout/dynamic_layouts/compact_layout.cpp
+++ b/src/layout/dynamic_layouts/compact_layout.cpp
@@ -1,0 +1,37 @@
+#include <lsqecc/layout/dynamic_layouts/compact_layout.hpp>
+
+
+namespace lsqecc
+{
+
+
+std::unique_ptr<Layout> make_compact_layout(size_t num_core_qubits)
+{
+    size_t t_distillation_region_cols = 5;
+    auto core_cols = static_cast<size_t>(std::ceil(static_cast<double>(num_core_qubits)/2.0));
+    size_t non_core_cols = /* S distillation + routing */ 3 + t_distillation_region_cols;
+    size_t total_cols = core_cols + non_core_cols;
+
+    AsciiLayoutSpec::CellGrid grid{
+            3, AsciiLayoutSpec::CellRow{total_cols, AsciiLayoutSpec::CellType::RoutingAncilla}};
+
+    // Fill the core qubits
+    std::fill_n(grid.at(0).begin(), core_cols,
+            AsciiLayoutSpec::CellType::LogicalComputationQubit_StandardBorderOrientation);
+    std::fill_n(grid.at(2).begin(), num_core_qubits-core_cols,
+            AsciiLayoutSpec::CellType::LogicalComputationQubit_StandardBorderOrientation);
+
+    // Add the distillation regions
+    grid.at(0).at(core_cols+1) = AsciiLayoutSpec::CellType::AncillaQubitLocation;
+    grid.at(2).at(core_cols+1) = AsciiLayoutSpec::CellType::AncillaQubitLocation;
+    std::fill_n(grid.at(0).begin() + static_cast<long>(core_cols) + 3, t_distillation_region_cols,
+    AsciiLayoutSpec::CellType::DistillationRegion_0);
+    std::fill_n(grid.at(1).begin() + static_cast<long>(core_cols) + 3, t_distillation_region_cols,
+    AsciiLayoutSpec::CellType::DistillationRegion_0);
+    std::fill_n(grid.at(2).begin() + static_cast<long>(core_cols) + 3, t_distillation_region_cols,
+    AsciiLayoutSpec::CellType::DistillationRegion_0);
+
+    return std::make_unique<LayoutFromSpec>(grid);
+}
+
+} // namespace lsqecc

--- a/src/layout/dynamic_layouts/compact_layout.cpp
+++ b/src/layout/dynamic_layouts/compact_layout.cpp
@@ -1,5 +1,6 @@
 #include <lsqecc/layout/dynamic_layouts/compact_layout.hpp>
 
+#include <cmath>
 
 namespace lsqecc
 {

--- a/src/layout/dynamic_layouts/determine_exposed_operators.cpp
+++ b/src/layout/dynamic_layouts/determine_exposed_operators.cpp
@@ -17,18 +17,17 @@ void RotatableSingleQubitPatchExposedOperators::rotate()
     z_exposed = !z_exposed;
 }
 
-tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> determine_exposed_core_operators(const Layout& layout)
+tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> determine_exposed_core_operators(
+        const Layout& layout, const tsl::ordered_set<PatchId>& core_qubit_ids)
 {
     tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> out;
 
 
-    DenseSlice first_slice{layout};
+    DenseSlice first_slice{layout, core_qubit_ids};
 
-    for(const SparsePatch& patch : layout.core_patches())
+    for(const PatchId& patch_id : core_qubit_ids)
     {
-        if(!patch.id) continue;
-
-        out[*patch.id] = determine_operators_exposed_for_patch(patch, first_slice);
+        out[patch_id] = determine_operators_exposed_for_patch(first_slice.get_sparse_patch_by_id(patch_id).value(), first_slice);
     }
     return out;
 }

--- a/src/layout/dynamic_layouts/determine_exposed_operators.cpp
+++ b/src/layout/dynamic_layouts/determine_exposed_operators.cpp
@@ -1,0 +1,61 @@
+#include <lsqecc/layout/dynamic_layouts/determine_exposed_operators.hpp>
+#include <lsqecc/patches/dense_slice.hpp>
+
+namespace lsqecc
+{
+
+bool RotatableSingleQubitPatchExposedOperators::is_exposed(const PauliOperator op) const
+{
+    if(op == PauliOperator::X) return x_exposed;
+    if(op == PauliOperator::Z) return z_exposed;
+    return false;
+}
+
+void RotatableSingleQubitPatchExposedOperators::rotate()
+{
+    x_exposed = !x_exposed;
+    z_exposed = !z_exposed;
+}
+
+tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> determine_exposed_core_operators(const Layout& layout)
+{
+    tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators> out;
+
+
+    DenseSlice first_slice{layout};
+
+    for(const SparsePatch& patch : layout.core_patches())
+    {
+        if(!patch.id) continue;
+
+        out[*patch.id] = determine_operators_exposed_for_patch(patch, first_slice);
+    }
+    return out;
+}
+
+
+
+RotatableSingleQubitPatchExposedOperators determine_operators_exposed_for_patch(const SparsePatch& patch, const Slice& slice)
+{
+    RotatableSingleQubitPatchExposedOperators out{false, false};
+
+    if(const auto* cell = get_if<SingleCellOccupiedByPatch>(&patch.cells))
+    {
+        for( const Cell& neighbour : slice.get_neigbours_within_slice(cell->cell))
+        {
+            if(!slice.is_cell_free(neighbour)) continue;
+
+            if(cell->get_boundary_with(neighbour))
+            {
+                if(cell->have_boundary_of_type_with(PauliOperator::X, neighbour))
+                    out.x_exposed = true;
+                if(cell->have_boundary_of_type_with(PauliOperator::Z, neighbour))
+                    out.z_exposed = true;
+            }
+        }
+    }
+    else LSTK_NOT_IMPLEMENTED;
+    return out;
+}
+
+}

--- a/src/ls_instructions/boundary_rotation_injection_stream.cpp
+++ b/src/ls_instructions/boundary_rotation_injection_stream.cpp
@@ -14,7 +14,7 @@ BoundaryRotationInjectionStream::BoundaryRotationInjectionStream(std::unique_ptr
                                                                  const lsqecc::Layout &layout)
 : BoundaryRotationInjectionStream(
         std::move(source),
-        std::move(determine_exposed_core_operators(layout)))
+        determine_exposed_core_operators(layout, source->core_qubits()))
 {}
 
 
@@ -47,12 +47,9 @@ LSInstruction BoundaryRotationInjectionStream::get_next_instruction()
             }
         }
     }
+    next_instructions_.push(new_instruction);
 
-    // Resume by figuring out what to do with the ancillas that arise from CNOTs
-    // idea: add one more cnot annotation to place the ancilla
-    // risk: might need to be able to wait 2 steps for a T state distillation to free up
-
-    return new_instruction;
+    return lstk::queue_pop(next_instructions_);
 }
 
 }

--- a/src/ls_instructions/boundary_rotation_injection_stream.cpp
+++ b/src/ls_instructions/boundary_rotation_injection_stream.cpp
@@ -1,0 +1,58 @@
+#include <lsqecc/ls_instructions/boundary_rotation_injection_stream.hpp>
+
+namespace lsqecc
+{
+
+
+BoundaryRotationInjectionStream::BoundaryRotationInjectionStream(
+        std::unique_ptr<LSInstructionStream> &&source,
+        tsl::ordered_map<PatchId, RotatableSingleQubitPatchExposedOperators>&& starting_exposed_operators)
+        : source_(std::move(source)), exposed_operators_(std::move(starting_exposed_operators))
+{}
+
+BoundaryRotationInjectionStream::BoundaryRotationInjectionStream(std::unique_ptr<LSInstructionStream> &&source,
+                                                                 const lsqecc::Layout &layout)
+: BoundaryRotationInjectionStream(
+        std::move(source),
+        std::move(determine_exposed_core_operators(layout)))
+{}
+
+
+bool BoundaryRotationInjectionStream::has_next_instruction() const
+{
+    return !next_instructions_.empty() || source_->has_next_instruction();
+}
+
+const tsl::ordered_set<PatchId> &BoundaryRotationInjectionStream::core_qubits() const
+{
+    return source_->core_qubits();
+}
+
+LSInstruction BoundaryRotationInjectionStream::get_next_instruction()
+{
+    if(!next_instructions_.empty()) return lstk::queue_pop(next_instructions_);
+
+    if(!source_->has_next_instruction())
+            throw std::logic_error{"BoundaryRotationInjectionStream: No more instructions from source"};
+
+    LSInstruction new_instruction = source_->get_next_instruction();
+    if(const auto* mpm = std::get_if<MultiPatchMeasurement>(&new_instruction.operation))
+    {
+        for(const PatchId patch_id : new_instruction.get_operating_patches())
+        {
+            if(exposed_operators_.contains(patch_id) && !exposed_operators_.at(patch_id).is_exposed(mpm->observable.at(patch_id)))
+            {
+                next_instructions_.push({RotateSingleCellPatch{patch_id}});
+                exposed_operators_.at(patch_id).rotate();
+            }
+        }
+    }
+
+    // Resume by figuring out what to do with the ancillas that arise from CNOTs
+    // idea: add one more cnot annotation to place the ancilla
+    // risk: might need to be able to wait 2 steps for a T state distillation to free up
+
+    return new_instruction;
+}
+
+}

--- a/src/ls_instructions/ls_instruction_stream.cpp
+++ b/src/ls_instructions/ls_instruction_stream.cpp
@@ -43,7 +43,8 @@ LSInstructionStreamFromFile::LSInstructionStreamFromFile(std::istream& instructi
     if(!next_instruction_)
         throw std::runtime_error("No instructions");
 
-    LSInstruction first_instruction = get_next_instruction();
+    LSInstruction first_instruction = next_instruction_.value();
+    advance_instruction();
     if(!std::holds_alternative<DeclareLogicalQubitPatches>(first_instruction.operation))
         throw std::runtime_error("First instruction must be qubit declaration");
 
@@ -154,11 +155,14 @@ tsl::ordered_set<PatchId> core_qubits_from_gate_stream(GateStream& gate_stream)
 }
 
 
-LSInstructionStreamFromGateStream::LSInstructionStreamFromGateStream(GateStream& gate_stream, CNOTCorrectionMode cnot_correction_mode)
+LSInstructionStreamFromGateStream::LSInstructionStreamFromGateStream(
+        GateStream& gate_stream,
+        CNOTCorrectionMode cnot_correction_mode,
+        IdGenerator& id_generator)
 : gate_stream_(gate_stream),
   next_instructions_(),
   core_qubits_(core_qubits_from_gate_stream(gate_stream)),
-  instruction_generator_(*std::max_element(core_qubits_.begin(), core_qubits_.end())+1),
+  instruction_generator_(id_generator),
   cnot_correction_mode_(cnot_correction_mode)
 {
 }

--- a/src/ls_instructions/ls_instructions_from_gates.cpp
+++ b/src/ls_instructions/ls_instructions_from_gates.cpp
@@ -4,19 +4,14 @@ namespace lsqecc
 {
 
 
-LSIinstructionFromGatesGenerator::LSIinstructionFromGatesGenerator(PatchId ancilla_state_id_start)
-: ancilla_state_id_counter_(ancilla_state_id_start)
+LSIinstructionFromGatesGenerator::LSIinstructionFromGatesGenerator(IdGenerator& id_generator)
+: id_generator_(id_generator)
 {}
-
-PatchId LSIinstructionFromGatesGenerator::get_next_ancilla_state_id()
-{
-    return ancilla_state_id_counter_++;
-}
 
 std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_t_gate_instructions(PatchId target_id)
 {
     std::queue<LSInstruction> next_instructions;
-    PatchId new_magic_state_id = get_next_ancilla_state_id();
+    PatchId new_magic_state_id = id_generator_.new_id();
     next_instructions.push({.operation={MagicStateRequest{new_magic_state_id, MagicStateRequest::DEFAULT_WAIT}}});
     next_instructions.push({.operation={
             MultiPatchMeasurement{.observable={
@@ -47,7 +42,7 @@ std::queue<LSInstruction> LSIinstructionFromGatesGenerator::make_cnot_instructio
         place_ancilla_next_to = std::make_pair(target_id, PauliOperator::Z);
 
     std::queue<LSInstruction> next_instructions;
-    PatchId ancilla_id = get_next_ancilla_state_id();
+    PatchId ancilla_id = id_generator_.new_id();
     next_instructions.push({.operation={PatchInit{
             ancilla_id, PatchInit::InitializeableStates::Plus, place_ancilla_next_to}}});
 

--- a/src/ls_instructions/teleported_s_gate_injection_stream.cpp
+++ b/src/ls_instructions/teleported_s_gate_injection_stream.cpp
@@ -1,0 +1,64 @@
+//
+// Created by george on 26/09/22.
+//
+
+#include <lsqecc/ls_instructions/teleported_s_gate_injection_stream.hpp>
+
+
+namespace lsqecc
+{
+
+TeleportedSGateInjectionStream::TeleportedSGateInjectionStream(std::unique_ptr<LSInstructionStream> &&source,
+                                                               IdGenerator& id_generator)
+ : source_(std::move(source)), id_generator_(id_generator)
+{}
+
+
+bool TeleportedSGateInjectionStream::has_next_instruction() const
+{
+    return !next_instructions_.empty() || source_->has_next_instruction();
+}
+
+
+const tsl::ordered_set<PatchId> &TeleportedSGateInjectionStream::core_qubits() const
+{
+    return source_->core_qubits();
+}
+
+LSInstruction TeleportedSGateInjectionStream::get_next_instruction()
+{
+    if(!next_instructions_.empty()) return lstk::queue_pop(next_instructions_);
+
+    if(!source_->has_next_instruction())
+        throw std::logic_error{"TeleportedSGateInjectionStream: No more instructions from source"};
+
+    LSInstruction new_instruction = source_->get_next_instruction();
+    const auto* sgate = std::get_if<SingleQubitOp>(&new_instruction.operation);
+    if( sgate && sgate->op == SingleQubitOp::Operator::S && core_qubits().contains(sgate->target))
+    {
+        const PatchId new_ancilla_id = id_generator_.new_id();
+
+        next_instructions_.push({.operation={PatchInit{
+                new_ancilla_id, PatchInit::InitializeableStates::Plus}}});
+        // S-Gate distillation
+        next_instructions_.push({.operation={
+                SingleQubitOp{
+                    .target = new_ancilla_id,
+                    .op = SingleQubitOp::Operator::S}}});
+        // Teleport the state
+        next_instructions_.push({.operation={
+                MultiPatchMeasurement{.observable={
+                        {new_ancilla_id, PauliOperator::Z},
+                        {sgate->target, PauliOperator::Z},
+                },.is_negative=false}}});
+        next_instructions_.push({.operation={SinglePatchMeasurement{new_ancilla_id, PauliOperator::Z, false}}});
+    }
+    else
+    {
+        next_instructions_.push(new_instruction);
+    }
+
+    return lstk::queue_pop(next_instructions_);
+}
+
+}

--- a/src/patches/dense_patch_computation.cpp
+++ b/src/patches/dense_patch_computation.cpp
@@ -4,7 +4,6 @@ namespace lsqecc
 {
 
 
-
 DenseSlice first_dense_slice_from_layout(const Layout& layout, const tsl::ordered_set<PatchId>& core_qubit_ids)
 {
     DenseSlice slice(layout);
@@ -335,8 +334,7 @@ DensePatchComputationResult run_through_dense_slices(
         Router& router,
         std::optional<std::chrono::seconds> timeout,
         const DenseSliceVisitor& slice_visitor,
-        bool graceful,
-        std::ostream& log)
+        bool graceful)
 {
 
     DensePatchComputationResult res;

--- a/src/patches/dense_patch_computation.cpp
+++ b/src/patches/dense_patch_computation.cpp
@@ -4,6 +4,7 @@ namespace lsqecc
 {
 
 
+
 DenseSlice first_dense_slice_from_layout(const Layout& layout, const tsl::ordered_set<PatchId>& core_qubit_ids)
 {
     DenseSlice slice(layout);
@@ -334,7 +335,8 @@ DensePatchComputationResult run_through_dense_slices(
         Router& router,
         std::optional<std::chrono::seconds> timeout,
         const DenseSliceVisitor& slice_visitor,
-        bool graceful)
+        bool graceful,
+        std::ostream& log)
 {
 
     DensePatchComputationResult res;

--- a/src/patches/dense_patch_computation.cpp
+++ b/src/patches/dense_patch_computation.cpp
@@ -292,7 +292,9 @@ InstructionApplicationResult try_apply_instruction(
 
     }
 
-    return {std::make_unique<std::runtime_error>("Unhandled LS instruction in PatchComputation"),{}};
+    std::stringstream s;
+    s << "Unhandled LS instruction in PatchComputation: " << instruction;
+    return {std::make_unique<std::runtime_error>(s.str()),{}};
 }
 
 

--- a/src/patches/dense_patch_computation.cpp
+++ b/src/patches/dense_patch_computation.cpp
@@ -4,37 +4,6 @@ namespace lsqecc
 {
 
 
-DenseSlice first_dense_slice_from_layout(const Layout& layout, const tsl::ordered_set<PatchId>& core_qubit_ids)
-{
-    DenseSlice slice(layout);
-
-    if (layout.core_patches().size()<core_qubit_ids.size())
-        throw std::runtime_error("Not enough Init patches for all ids");
-
-    auto core_qubit_ids_itr = core_qubit_ids.begin();
-    for (const SparsePatch& p : layout.core_patches())
-    {
-        Cell cell = slice.place_sparse_patch(p);
-        slice.patch_at(cell)->id = *core_qubit_ids_itr++;
-    }
-
-    for(const MultipleCellsOccupiedByPatch& distillation_region: layout.distillation_regions())
-    {
-        for (const SingleCellOccupiedByPatch& cell: distillation_region.sub_cells)
-        {
-            slice.patch_at(cell.cell) = DensePatch{
-                Patch{PatchType::Distillation,PatchActivity::Distillation,std::nullopt},
-                static_cast<CellBoundaries>(cell)};
-        }
-    }
-
-    size_t distillation_time_offset = 0;
-    for(auto t : layout.distillation_times())
-        slice.time_to_next_magic_state_by_distillation_region.push_back(t+distillation_time_offset++);
-
-    return slice;
-}
-
 std::optional<Cell> find_place_for_magic_state(const DenseSlice& slice, const Layout& layout, size_t distillation_region_idx)
 {
     for(const auto& cell: layout.distilled_state_locations(distillation_region_idx))
@@ -341,7 +310,7 @@ DensePatchComputationResult run_through_dense_slices(
 
     auto run = [&]()
     {
-        DenseSlice slice = first_dense_slice_from_layout(layout, instruction_stream.core_qubits());
+        DenseSlice slice{layout, instruction_stream.core_qubits()};
 
         auto start = std::chrono::steady_clock::now();
 

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -4,6 +4,7 @@
 #include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
 #include <lsqecc/layout/ascii_layout_spec.hpp>
 #include <lsqecc/layout/router.hpp>
+#include <lsqecc/layout/dynamic_layouts/compact_layout.hpp>
 #include <lsqecc/patches/slices_to_json.hpp>
 #include <lsqecc/patches/slice.hpp>
 #include <lsqecc/patches/sparse_patch_computation.hpp>
@@ -104,6 +105,10 @@ namespace lsqecc
         parser.add_argument()
                 .names({"--cnotcorrections"})
                 .description("Add Xs and Zs to correct the the negative outcomes: never (default), always") // TODO add random
+                .required(false);
+        parser.add_argument()
+                .names({"--compactlayout"})
+                .description("Uses Litinski's compact layout, incompatible with -l")
                 .required(false);
         parser.enable_help();
 
@@ -206,7 +211,9 @@ namespace lsqecc
         }
 
         std::unique_ptr<Layout> layout;
-        if(parser.exists("l"))
+        if (parser.exists("compactlayout"))
+            layout = make_compact_layout(instruction_stream->core_qubits().size());
+        else if(parser.exists("l"))
             layout = std::make_unique<LayoutFromSpec>(file_to_string(parser.get<std::string>("l")));
         else
             layout = std::make_unique<SimpleLayout>(instruction_stream->core_qubits().size());

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -3,6 +3,7 @@
 #include <lsqecc/gates/parse_gates.hpp>
 #include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
 #include <lsqecc/ls_instructions/boundary_rotation_injection_stream.hpp>
+#include <lsqecc/ls_instructions/teleported_s_gate_injection_stream.hpp>
 #include <lsqecc/layout/ascii_layout_spec.hpp>
 #include <lsqecc/layout/router.hpp>
 #include <lsqecc/layout/dynamic_layouts/compact_layout.hpp>
@@ -221,7 +222,9 @@ namespace lsqecc
         if (parser.exists("compactlayout"))
         {
             layout = make_compact_layout(instruction_stream->core_qubits().size());
+            instruction_stream = std::make_unique<TeleportedSGateInjectionStream>(std::move(instruction_stream), id_generator);
             instruction_stream = std::make_unique<BoundaryRotationInjectionStream>(std::move(instruction_stream), *layout);
+
         }
         else if(parser.exists("l"))
             layout = std::make_unique<LayoutFromSpec>(file_to_string(parser.get<std::string>("l")));

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -2,6 +2,7 @@
 
 #include <lsqecc/gates/parse_gates.hpp>
 #include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
+#include <lsqecc/ls_instructions/boundary_rotation_injection_stream.hpp>
 #include <lsqecc/layout/ascii_layout_spec.hpp>
 #include <lsqecc/layout/router.hpp>
 #include <lsqecc/layout/dynamic_layouts/compact_layout.hpp>
@@ -212,7 +213,10 @@ namespace lsqecc
 
         std::unique_ptr<Layout> layout;
         if (parser.exists("compactlayout"))
+        {
             layout = make_compact_layout(instruction_stream->core_qubits().size());
+            instruction_stream = std::make_unique<BoundaryRotationInjectionStream>(std::move(instruction_stream), *layout);
+        }
         else if(parser.exists("l"))
             layout = std::make_unique<LayoutFromSpec>(file_to_string(parser.get<std::string>("l")));
         else

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -159,6 +159,8 @@ namespace lsqecc
 
         std::ifstream file_stream;
         std::unique_ptr<LSInstructionStream> instruction_stream;
+        IdGenerator id_generator;
+
         if(parser.exists("i"))
         {
             if(parser.exists("q")){
@@ -175,8 +177,11 @@ namespace lsqecc
             instruction_stream = std::make_unique<LSInstructionStreamFromFile>(file_stream);
         }
         if(!instruction_stream && !parser.exists("q"))
+        {
             instruction_stream = std::make_unique<LSInstructionStreamFromFile>(in_stream);
-
+            id_generator.set_start(*std::max(instruction_stream->core_qubits().begin(),
+                                             instruction_stream->core_qubits().end()));
+        }
 
         std::unique_ptr<GateStream> gate_stream;
         if(parser.exists("q"))
@@ -202,7 +207,8 @@ namespace lsqecc
                     return -1;
                 }
             }
-            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream, cnot_correction_mode);
+            id_generator.set_start(gate_stream->get_qreg().size);
+            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream, cnot_correction_mode, id_generator);
         }
 
         if(parser.exists("lli"))

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -17,6 +17,7 @@
 #include <nlohmann/json.hpp>
 
 #include <iostream>
+#include <ostream>
 #include <string_view>
 #include <sstream>
 #include <stdexcept>
@@ -27,6 +28,21 @@
 
 namespace lsqecc
 {
+
+    class NullStream : public std::ostream
+    {
+    public:
+        NullStream()
+        : std::ostream(&null_buffer) {}
+
+        static NullStream instance;
+    private:
+        struct NullBuffer : public std::streambuf
+        {
+            int overflow(int c) override { return c; }
+        };
+        NullBuffer null_buffer;
+    };
 
 
 
@@ -95,6 +111,10 @@ namespace lsqecc
                 .description("Set how slices are represented: dense (default), sparse")
                 .required(false);
         parser.add_argument()
+                .names({"--computation_logging"})
+                .description("Enables logging during the creation of the patch computation")
+                .required(false);
+        parser.add_argument()
                 .names({"--graceful"})
                 .description("If there is an error when slicing, print the error and terminate")
                 .required(false);
@@ -103,11 +123,11 @@ namespace lsqecc
                 .description("Output LLI instead of JSONs")
                 .required(false);
         parser.add_argument()
-                .names({"--cnotcorrections"})
+                .names({"--cnot_corrections"})
                 .description("Add Xs and Zs to correct the the negative outcomes: never (default), always") // TODO add random
                 .required(false);
         parser.add_argument()
-                .names({"--compactlayout"})
+                .names({"--compact_layout"})
                 .description("Uses Litinski's compact layout, incompatible with -l")
                 .required(false);
         parser.enable_help();
@@ -189,15 +209,15 @@ namespace lsqecc
             gate_stream = std::make_unique<GateStreamFromFile>(file_stream);
 
             CNOTCorrectionMode cnot_correction_mode = CNOTCorrectionMode::NEVER;
-            if(parser.exists("cnotcorrections"))
+            if(parser.exists("cnot_corrections"))
             {
-                if(parser.get<std::string>("cnotcorrections") == "always")
+                if(parser.get<std::string>("cnot_corrections") == "always")
                     cnot_correction_mode = CNOTCorrectionMode::ALWAYS;
-                else if(parser.get<std::string>("cnotcorrections") == "never")
+                else if(parser.get<std::string>("cnot_corrections") == "never")
                     cnot_correction_mode = CNOTCorrectionMode::NEVER;
                 else
                 {
-                    err_stream << "Unknown CNOT correction mode: " << parser.get<std::string>("cnotcorrections") <<std::endl;
+                    err_stream << "Unknown CNOT correction mode: " << parser.get<std::string>("cnot_corrections") <<std::endl;
                     return -1;
                 }
             }
@@ -211,7 +231,7 @@ namespace lsqecc
         }
 
         std::unique_ptr<Layout> layout;
-        if (parser.exists("compactlayout"))
+        if (parser.exists("compact_layout"))
             layout = make_compact_layout(instruction_stream->core_qubits().size());
         else if(parser.exists("l"))
             layout = std::make_unique<LayoutFromSpec>(file_to_string(parser.get<std::string>("l")));
@@ -299,18 +319,21 @@ namespace lsqecc
 
         auto start = lstk::now();
 
-
         std::unique_ptr<PatchComputationResult> computation_result;
 
         if(parser.exists("a") && parser.get<std::string>("a") == "sparse")
-            computation_result = std::make_unique<SparsePatchComputation>(
-                std::move(*instruction_stream),
-                std::move(layout),
-                std::move(router),
-                timeout,
-                visitor_with_progress,
-                parser.exists("graceful")
-            );
+        {
+            err_stream << "Sparse patch representation is not supported at the moment" << std::endl;
+            return 1;
+        }
+//            computation_result = std::make_unique<SparsePatchComputation>(
+//                std::move(*instruction_stream),
+//                std::move(layout),
+//                std::move(router),
+//                timeout,
+//                visitor_with_progress,
+//                parser.exists("graceful")
+//            );
         else if (!parser.exists("a") || (parser.exists("a") && parser.get<std::string>("a") == "dense"))
         {
             computation_result = std::make_unique<DensePatchComputationResult>(run_through_dense_slices(
@@ -319,7 +342,8 @@ namespace lsqecc
                     *router,
                     timeout,
                     [&](const DenseSlice& s){visitor_with_progress(s);},
-                    parser.exists("graceful")
+                    parser.exists("graceful"),
+                    parser.exists("computation_logging") ? out_stream : NullStream::instance
             ));
         } else
         {


### PR DESCRIPTION
Adds basic functionality to run Lattice Surgery Computations in a fashion similar to [Litinski's compact layout](https://arxiv.org/abs/1808.02892):

- Generation of compact layouts
- Uses patch rotations to expose operators. It does so by manually tracking which patches are exposed via the `BoundaryRotationInjectionStream`, which inserts instructions to rotate patches. This way, when the slicer runs, it always finds the the boundary of the patch it needs exposed.

### Demo

Shows patch rotations and some basic parallelization features. Note how the ancilla mediating the CNOTs are allocated away from the control and target.

```qasm
OPENQASM 2.0;
include "qelib1.inc";

qreg q[15];

cx q[0],q[10];
cx q[1],q[3];
cx q[5],q[7];
t q[2];
```

![Peek 2022-09-25 22-21](https://user-images.githubusercontent.com/36427091/192199442-4150c274-f0c0-4c7b-8d17-4ff0b44341e1.gif)

### To-do before merging
- [x] Handle S gates  (either by moving the core qubits or teleporting)
- [ ] ~~More testing~~ New CR