### PR TITLE
Add emscripten build to CI

### DIFF
--- a/.github/workflows/emscripten_build.yml
+++ b/.github/workflows/emscripten_build.yml
@@ -1,0 +1,34 @@
+name: Emscripten build
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+
+# Follows https://gist.github.com/WesThorburn/00c47b267a0e8c8431e06b14997778e4
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: prepare emsdk
+        run: |
+          cd external/emsdk
+          ./emsdk install latest
+          ./emsdk activate latest
+          cd ../..
+
+      - name: Build project
+        run: |
+          source ./external/emsdk/emsdk_env.sh
+          mkdir build
+          emcmake cmake -Bbuild -H.
+          make -Cbuild

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 CMake*
 *.cmake
 Makefile
-cmake-build-debug
+*-build*
 .idea
 *.a

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/googletest"]
 	path = external/googletest
 	url = https://github.com/google/googletest
+[submodule "external/emsdk"]
+	path = external/emsdk
+	url = https://github.com/emscripten-core/emsdk.git


### PR DESCRIPTION
 * Adds [Emscripten's sdk](https://github.com/emscripten-core/emsdk) as a submodule
 * Adds github action to build

The build produces 2 artifacts: `lsqecc_emscripten.js` and `lsqecc_emscripten.wasm` these can run the slicer in the browser. A PR to the web-ui repo will soon follow. A next step is to auto deploy these two artifacts to s3