### PR TITLE
Print LLI slice by slice + instruction visitor

### DIFF
--- a/include/lsqecc/patches/dense_patch_computation.hpp
+++ b/include/lsqecc/patches/dense_patch_computation.hpp
@@ -19,6 +19,7 @@ namespace lsqecc {
 
 
 using DenseSliceVisitor = std::function<void(const DenseSlice& slice)>;
+using LSInstructionVisitor = std::function<void(const LSInstruction& visitor)>;
 
 struct DensePatchComputationResult : public PatchComputationResult {
     using PatchComputationResult::PatchComputationResult;
@@ -38,6 +39,7 @@ DensePatchComputationResult run_through_dense_slices(
         Router& router,
         std::optional<std::chrono::seconds> timeout,
         const DenseSliceVisitor& slice_visitor,
+        const LSInstructionVisitor& instruction_visitor,
         bool graceful,
         bool nostagger);
 

--- a/regression_tests/cases/help.spec
+++ b/regression_tests/cases/help.spec
@@ -9,7 +9,7 @@ Options:
     -r, --router           Set a router: graph_search (default), graph_search_cached
     -g, --graph-search     Set a graph search provider: custom (default), boost (not always available)
     --graceful             If there is an error when slicing, print the error and terminate
-    --printlli             Output LLI instead of JSONs
+    --printlli             Output LLI instead of JSONs. options: before (default), sliced (prints lli on the same slice separated by semicolons)
     --noslices             Do the slicing but don't write the slices out
     --cnotcorrections      Add Xs and Zs to correct the the negative outcomes: never (default), always
     --compactlayout        Uses Litinski's compact layout, incompatible with -l

--- a/regression_tests/cases/sliced_lli/1.case.sh
+++ b/regression_tests/cases/sliced_lli/1.case.sh
@@ -1,0 +1,12 @@
+INPUT="
+DeclareLogicalQubitPatches 0,1,2,3,4,5,6
+Init 100 +
+MultiBodyMeasure 0:X,4:X
+MultiBodyMeasure 5:Z,6:Z
+MultiBodyMeasure 2:Z,3:Z
+RotateSingleCellPatch 100
+HGate 1
+HGate 1
+RotateSingleCellPatch 1
+"
+echo "$INPUT" | lsqecc_slicer -l ../examples/core4by4layout.txt --printlli sliced

--- a/regression_tests/cases/sliced_lli/1.spec
+++ b/regression_tests/cases/sliced_lli/1.spec
@@ -1,0 +1,7 @@
+Init 100 |+>;MultiBodyMeasure 0:X,4:X;MultiBodyMeasure 5:Z,6:Z;MultiBodyMeasure 2:Z,3:Z;
+RotateSingleCellPatch 100;
+BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(1);BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(0);HGate 1;
+HGate 1;HGate 1 #WaitAtMostFor 2;
+RotateSingleCellPatch 1;
+BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(1);BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(0);
+

--- a/regression_tests/cases/sliced_lli/1.spec
+++ b/regression_tests/cases/sliced_lli/1.spec
@@ -1,7 +1,7 @@
-Init 100 |+>;MultiBodyMeasure 0:X,4:X;MultiBodyMeasure 5:Z,6:Z;MultiBodyMeasure 2:Z,3:Z;
-RotateSingleCellPatch 100;
-BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(1);BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(0);HGate 1;
-HGate 1;HGate 1 #WaitAtMostFor 2;
-RotateSingleCellPatch 1;
-BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(1);BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(0);
+Init 100 |+>;MultiBodyMeasure 0:X,4:X;MultiBodyMeasure 5:Z,6:Z;MultiBodyMeasure 2:Z,3:Z;RotateSingleCellPatch 100;
+BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(1);
+BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(0);HGate 1;
+HGate 1 #WaitAtMostFor 2;RotateSingleCellPatch 1;
+BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(1);
+BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(0);
 

--- a/regression_tests/cases/sliced_lli/1.spec
+++ b/regression_tests/cases/sliced_lli/1.spec
@@ -1,7 +1,7 @@
 Init 100 |+>;MultiBodyMeasure 0:X,4:X;MultiBodyMeasure 5:Z,6:Z;MultiBodyMeasure 2:Z,3:Z;RotateSingleCellPatch 100;
-BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(1);
-BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(0);HGate 1;
+BusyRegion OccupiedRegion:(2|5),OccupiedRegion:(2|6),StepsToClear(1);
+BusyRegion OccupiedRegion:(2|5),OccupiedRegion:(2|6),StepsToClear(0);HGate 1;
 HGate 1 #WaitAtMostFor 2;RotateSingleCellPatch 1;
-BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(1);
-BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(0);
+BusyRegion OccupiedRegion:(1|2),OccupiedRegion:(1|3),StepsToClear(1);
+BusyRegion OccupiedRegion:(1|2),OccupiedRegion:(1|3),StepsToClear(0);
 

--- a/src/gates/gate_approximator.cpp
+++ b/src/gates/gate_approximator.cpp
@@ -1,6 +1,7 @@
 #include <lsqecc/gates/gate_approximator.hpp>
 
 #include <algorithm>
+#include <memory>
 
 
 bool is_power_of_two(lsqecc::ArbitraryPrecisionInteger n)

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -99,8 +99,9 @@ std::ostream& operator<<(std::ostream& os, const BusyRegion& instruction)
 {
     os << LSInstructionPrint<BusyRegion>::name << " ";
     for (const auto &cell: instruction.region.cells)
-        os << "OccupiedRegion:" << "(" << cell.cell.row << "," << cell.cell.col << ")";
-    return os << " " << "StateAfterClearing:TODO"; // TODO
+        os << "OccupiedRegion:" << "(" << cell.cell.row << "|" << cell.cell.col << ")";
+    // TODO: add state_after_clearing if needed. Requires printing a SparsePatch
+    return os << "," << "StepsToClear(" << instruction.steps_to_clear <<")";
 }
 
 }

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -99,9 +99,9 @@ std::ostream& operator<<(std::ostream& os, const BusyRegion& instruction)
 {
     os << LSInstructionPrint<BusyRegion>::name << " ";
     for (const auto &cell: instruction.region.cells)
-        os << "OccupiedRegion:" << "(" << cell.cell.row << "|" << cell.cell.col << ")";
+        os << "OccupiedRegion:" << "(" << cell.cell.row << "|" << cell.cell.col << "),";
     // TODO: add state_after_clearing if needed. Requires printing a SparsePatch
-    return os << "," << "StepsToClear(" << instruction.steps_to_clear <<")";
+    return os << "StepsToClear(" << instruction.steps_to_clear <<")";
 }
 
 }

--- a/src/patches/dense_patch_computation.cpp
+++ b/src/patches/dense_patch_computation.cpp
@@ -345,6 +345,7 @@ DensePatchComputationResult run_through_dense_slices(
         Router& router,
         std::optional<std::chrono::seconds> timeout,
         const DenseSliceVisitor& slice_visitor,
+        const LSInstructionVisitor& instruction_visitor,
         bool graceful,
         bool nostagger)
 {
@@ -384,6 +385,7 @@ DensePatchComputationResult run_through_dense_slices(
                 slice_visitor(slice);
                 throw std::runtime_error{application_result.maybe_error->what()};
             }
+            instruction_visitor(instruction);
 
 
             if (timeout && lstk::since(start)>*timeout)


### PR DESCRIPTION
Adds two options to the `--printlli` flag. One for the regular use, plus one to print slice by slice

Produces output such as

```
Init 100 |+>;MultiBodyMeasure 0:X,4:X;MultiBodyMeasure 5:Z,6:Z;MultiBodyMeasure 2:Z,3:Z;
RotateSingleCellPatch 100;
BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(1);BusyRegion OccupiedRegion:(2|5)OccupiedRegion:(2|6),StepsToClear(0);HGate 1;
HGate 1;HGate 1 #WaitAtMostFor 2;
RotateSingleCellPatch 1;
BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(1);BusyRegion OccupiedRegion:(1|2)OccupiedRegion:(1|3),StepsToClear(0);
```

Where operations on the same line are on the same slice