### PR TITLE
Exclude .spec files from GH language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+regression_tests/cases/**/*.spec linguist-generated


### PR DESCRIPTION
Per [linguist doc](https://github.com/github/linguist/blob/master/docs/overrides.md)

*Not a Python repo* 😅 

![image](https://user-images.githubusercontent.com/46719079/219224323-7a6b3646-551c-449f-b7e5-77698b2007a0.png)

