### PR TITLE
npm: `Slicer.run()` to return Slices directly 

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -1,17 +1,13 @@
 // @ts-ignore
 import LsqeccModule from "../wasm/lsqecc_emscripten.js";
 
+import type { Slices, Slice, VisualArrayCell } from "./slices";
+
 type inputType = "lli" | "qasm";
 
 type cnotCorrections = "never" | "always";
 
 type layoutGenerator = "compact" | "edpc" | "";
-
-interface slicerResult {
-    err: string;
-    exit_code: number;
-    output: string;
-}
 
 class Slicer {
     private constructor(protected _module: any) {}
@@ -40,7 +36,7 @@ class Slicer {
         inputType: inputType = "lli",
         layoutGenerator: layoutGenerator = "",
         cnotCorrections: cnotCorrections = "never"
-    ): slicerResult {
+    ): Slices {
         if (inputType !== "qasm" && inputType !== "lli") {
             throw new Error(`Invalid argument inputType: ${inputType}`);
         }
@@ -61,8 +57,14 @@ class Slicer {
             input
         );
 
-        return JSON.parse(result);
+        const resultAsJson = JSON.parse(result);
+        if (resultAsJson.exit_code !== 0) {
+            throw new Error(`Exit code ${resultAsJson.exit_code}: ${resultAsJson.err}`);
+        }
+
+        return JSON.parse(resultAsJson.output) as Slices;
     }
 }
 
 export default Slicer;
+export type { Slices, Slice, VisualArrayCell };

--- a/npm/src/slices.ts
+++ b/npm/src/slices.ts
@@ -1,0 +1,19 @@
+type Orientation = "Top" | "Bottom" | "Left" | "Right";
+type EdgeType = "Solid" | "SolidStiched" | "Dashed" | "DashedStiched" | "AncillaJoin";
+
+type VisualArrayCell = {
+    edges: {
+        [key in Orientation]: EdgeType;
+    };
+    patch_type: "Qubit" | "DistillationQubit" | "Ancilla";
+    test: string;
+    activity: {
+        op: "I" | "X" | "Y" | "Z";
+        activity_type: "Unitary" | "Measurement";
+    };
+};
+
+type Slice = Array<Array<VisualArrayCell>>;
+type Slices = Array<Slice>;
+
+export type { Slices, Slice, VisualArrayCell };

--- a/npm/tests/index.test.ts
+++ b/npm/tests/index.test.ts
@@ -32,7 +32,7 @@ describe("Slicer", () => {
                 JSON.stringify({
                     err: "",
                     exit_code: 0,
-                    output: "some result",
+                    output: '{ "result": "something" }',
                 })
             );
         });
@@ -45,9 +45,7 @@ describe("Slicer", () => {
             );
 
             expect(result).toEqual({
-                err: "",
-                exit_code: 0,
-                output: "some result",
+                result: "something",
             });
         });
 
@@ -59,9 +57,7 @@ describe("Slicer", () => {
             );
 
             expect(result).toEqual({
-                err: "",
-                exit_code: 0,
-                output: "some result",
+                result: "something",
             });
         });
 
@@ -73,9 +69,7 @@ describe("Slicer", () => {
             );
 
             expect(result).toEqual({
-                err: "",
-                exit_code: 0,
-                output: "some result",
+                result: "something",
             });
         });
 
@@ -87,10 +81,21 @@ describe("Slicer", () => {
             );
 
             expect(result).toEqual({
-                err: "",
-                exit_code: 0,
-                output: "some result",
+                result: "something",
             });
         });
+    });
+
+    it("return error when exit code is not 0", () => {
+        mockRunSlicerProgramFromStrings.mockReturnValue(
+            JSON.stringify({
+                err: "some error",
+                exit_code: 100,
+                output: "",
+            })
+        );
+
+        const test = () => mockSlicer.run("some input");
+        expect(test).toThrow("Exit code 100: some error");
     });
 });


### PR DESCRIPTION
As title. If there is an error from the compiler it gets thrown instead.
