### PR TITLE
Add the creation of dependency DAGs from LLI and QASM 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ include_directories(external/include)
 add_library(
         lsqecclib
         src/dag/directed_graph.cpp
+        src/dag/domain_dags.cpp
         src/gates/parse_gates.cpp
         src/gates/gates.cpp
         src/gates/gate_approximator.cpp
@@ -192,6 +193,7 @@ if(NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR)
             tests/main.cpp
             tests/lstk/lstk.cpp
             tests/dag/directed_graph.cpp
+            tests/dag/domain_dags.cpp
             tests/dag/dependency_dag.cpp
             tests/gates/gate_approximator.cpp
             tests/gates/parse_gates.cpp

--- a/include/lsqecc/dag/commutation_trait.hpp
+++ b/include/lsqecc/dag/commutation_trait.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace lsqecc::dag
+{
+
+/**
+ * Instructions need to implement this trait to take advantage of parallelism in a dependancy dag
+ */
+template <typename Instruction>
+struct CommutationTrait
+{
+    // Requirement:
+    // Instructions commute -> maybe true
+    // Instructions don't commute -> definitely false
+    static bool can_commute(const Instruction& a, const Instruction& b);
+};
+
+} // namespace lsqecc::dag

--- a/include/lsqecc/dag/dependency_dag.hpp
+++ b/include/lsqecc/dag/dependency_dag.hpp
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <lsqecc/dag/directed_graph.hpp>
+#include <lsqecc/dag/commutation_trait.hpp>
 
 #include <vector>
 #include <iostream>
@@ -10,23 +13,9 @@ namespace lsqecc::dag {
 /**
  * A Dag representing dependancies between instructions, where instruction can be LLI gates or any other
  * Kind of instruction that can be modelled as having dependancies.
+ * 
+ * Instructions must impmlement the CommutationTrait to take advantage of commutation and not be dependent
  */
-
-
-/**
- * Instructions need to implement this trait to take advantage of parallelism in a dependancy dag
- */
-template <typename Instruction>
-struct CommutationTrait
-{
-    // Requirement:
-    // Instructions commute -> maybe true
-    // Instructions don't commute -> definitely false
-    static bool can_commute(const Instruction& a, const Instruction& b)
-    {
-        return false;
-    }
-};
 
 
 template<typename Instruction>

--- a/include/lsqecc/dag/directed_graph.hpp
+++ b/include/lsqecc/dag/directed_graph.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <algorithm>
 #include <tsl/ordered_map.h>
 #include <tsl/ordered_set.h>

--- a/include/lsqecc/dag/domain_dags.hpp
+++ b/include/lsqecc/dag/domain_dags.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
+#include <lsqecc/gates/parse_gates.hpp>
+
+#include <lsqecc/dag/dependency_dag.hpp>
+
+namespace lsqecc::dag {
+
+
+DependencyDag<LSInstruction> full_dependency_dag_from_instruction_stream(LSInstructionStream& instruction_stream);
+
+
+DependencyDag<gates::Gate> full_dependency_dag_from_gate_stream(GateStream& gate_stream);
+
+
+
+}

--- a/include/lsqecc/ls_instructions/ls_instructions.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions.hpp
@@ -5,10 +5,12 @@
 #include <stdexcept>
 #include <ostream>
 #include <unordered_set>
-#include <lsqecc/patches/patches.hpp>
 
 #include <tsl/ordered_map.h>
 #include <tsl/ordered_set.h>
+
+#include <lsqecc/patches/patches.hpp>
+#include <lsqecc/dag/commutation_trait.hpp>
 
 
 namespace lsqecc {
@@ -206,7 +208,23 @@ static inline std::string_view SingleQuibitOperatorName_to_string(SingleQubitOp:
 }
 
 
-}
+namespace dag {
+
+template<>
+struct CommutationTrait<LSInstruction>
+{
+    static bool can_commute(const LSInstruction& a, const LSInstruction& b)
+    {
+        return lstk::set_intersection(a.get_operating_patches(), b.get_operating_patches()).empty();
+    }
+};
+
+
+} // namespace dag
+
+
+
+} // namespace lsqecc
 
 
 #endif //LSQECC_LOGICAL_LATTICE_OPS_HPP

--- a/include/lsqecc/ls_instructions/ls_instructions.hpp
+++ b/include/lsqecc/ls_instructions/ls_instructions.hpp
@@ -107,7 +107,7 @@ struct LSInstruction {
 
     size_t wait_at_most_for = DEFAULT_MAX_WAIT;
 
-    std::vector<PatchId> get_operating_patches() const;
+    tsl::ordered_set<PatchId> get_operating_patches() const;
     bool operator==(const LSInstruction&) const = default;
 };
 

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -232,9 +232,10 @@ template<class T>
 tsl::ordered_set<T> set_intersection(const tsl::ordered_set<T>& a, const tsl::ordered_set<T>& b)
 {
     tsl::ordered_set<T> ret;
-    std::set_intersection(a.begin(), a.end(), b.begin(), b.end(), std::inserter(ret, ret.begin()));
+    for(const auto& item: a)
+        if(b.contains(item))
+            ret.insert(item);
     return ret;
-
 }
 
 

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -226,6 +226,15 @@ std::string join(IterableOfStringifiables iterable_of_stringifiables, std::strin
 
 }
 
+
+// Variant visitor helper
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+
+
+} // namespace lstk
+
 #define LSTK_THROW(exception_name, args) \
 throw exception_name{lstk::cat("Exception at ",__FILE__,":",__LINE__,args)}
 

--- a/include/lstk/lstk.hpp
+++ b/include/lstk/lstk.hpp
@@ -12,6 +12,8 @@
 #include <vector>
 #include <string>
 #include <queue>
+#include <tsl/ordered_set.h>
+#include <unordered_set>
 #include <string_view>
 #include <functional>
 #include <optional>
@@ -223,6 +225,15 @@ std::string join(IterableOfStringifiables iterable_of_stringifiables, std::strin
     }
     return acc;
 }
+
+
+// set operations
+template<class T>
+tsl::ordered_set<T> set_intersection(const tsl::ordered_set<T>& a, const tsl::ordered_set<T>& b)
+{
+    tsl::ordered_set<T> ret;
+    std::set_intersection(a.begin(), a.end(), b.begin(), b.end(), std::inserter(ret, ret.begin()));
+    return ret;
 
 }
 

--- a/regression_tests/cases/help.spec
+++ b/regression_tests/cases/help.spec
@@ -10,7 +10,7 @@ Options:
     -g, --graph-search     Set a graph search provider: custom (default), boost (not always available)
     --graceful             If there is an error when slicing, print the error and terminate
     --printlli             Output LLI instead of JSONs
-    --printdag             Prints a dependancy dag of the circuit. Modes: input (default), qasm, processedlli
+    --printdag             Prints a dependancy dag of the circuit. Modes: input (default), processedlli
     --noslices             Do the slicing but don't write the slices out
     --cnotcorrections      Add Xs and Zs to correct the the negative outcomes: never (default), always
     --layoutgenerator, -L  Automatically generates a layout for the given number of qubits. Incompatible with -l. Options:

--- a/regression_tests/cases/help.spec
+++ b/regression_tests/cases/help.spec
@@ -10,6 +10,7 @@ Options:
     -g, --graph-search     Set a graph search provider: custom (default), boost (not always available)
     --graceful             If there is an error when slicing, print the error and terminate
     --printlli             Output LLI instead of JSONs
+    --printdag             Prints a dependancy dag of the circuit. Modes: input (default), qasm, processedlli
     --noslices             Do the slicing but don't write the slices out
     --cnotcorrections      Add Xs and Zs to correct the the negative outcomes: never (default), always
     --layoutgenerator, -L  Automatically generates a layout for the given number of qubits. Incompatible with -l. Options:

--- a/regression_tests/cases/print_dag/print_dag.input_lli.case.sh
+++ b/regression_tests/cases/print_dag/print_dag.input_lli.case.sh
@@ -8,5 +8,6 @@ RotateSingleCellPatch 100
 HGate 1
 HGate 1
 RotateSingleCellPatch 1
+MultiBodyMeasure 0:Z,100:Z
 "
 echo "$INPUT" | lsqecc_slicer --printdag input

--- a/regression_tests/cases/print_dag/print_dag.input_lli.case.sh
+++ b/regression_tests/cases/print_dag/print_dag.input_lli.case.sh
@@ -1,0 +1,12 @@
+INPUT="
+DeclareLogicalQubitPatches 0,1,2,3,4,5,6
+Init 100 +
+MultiBodyMeasure 0:X,4:X
+MultiBodyMeasure 5:Z,6:Z
+MultiBodyMeasure 2:Z,3:Z
+RotateSingleCellPatch 100
+HGate 1
+HGate 1
+RotateSingleCellPatch 1
+"
+echo "$INPUT" | lsqecc_slicer --printdag input

--- a/regression_tests/cases/print_dag/print_dag.input_lli.spec
+++ b/regression_tests/cases/print_dag/print_dag.input_lli.spec
@@ -1,0 +1,14 @@
+digraph DirectedGraph {
+  0 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>Init 100 |+&gt;</b></td></tr><tr><td><font color="darkgray">node: 0</font></td></tr></table>>];
+  1 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 0:X,4:X</b></td></tr><tr><td><font color="darkgray">node: 1</font></td></tr></table>>];
+  2 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 5:Z,6:Z</b></td></tr><tr><td><font color="darkgray">node: 2</font></td></tr></table>>];
+  3 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 2:Z,3:Z</b></td></tr><tr><td><font color="darkgray">node: 3</font></td></tr></table>>];
+  4 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>RotateSingleCellPatch 100</b></td></tr><tr><td><font color="darkgray">node: 4</font></td></tr></table>>];
+  5 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>HGate 1</b></td></tr><tr><td><font color="darkgray">node: 5</font></td></tr></table>>];
+  6 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>HGate 1</b></td></tr><tr><td><font color="darkgray">node: 6</font></td></tr></table>>];
+  7 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>RotateSingleCellPatch 1</b></td></tr><tr><td><font color="darkgray">node: 7</font></td></tr></table>>];
+  0 -> 4;
+  5 -> 6;
+  5 -> 7;
+  6 -> 7;
+}

--- a/regression_tests/cases/print_dag/print_dag.input_lli.spec
+++ b/regression_tests/cases/print_dag/print_dag.input_lli.spec
@@ -7,7 +7,11 @@ digraph DirectedGraph {
   5 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>HGate 1</b></td></tr><tr><td><font color="darkgray">node: 5</font></td></tr></table>>];
   6 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>HGate 1</b></td></tr><tr><td><font color="darkgray">node: 6</font></td></tr></table>>];
   7 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>RotateSingleCellPatch 1</b></td></tr><tr><td><font color="darkgray">node: 7</font></td></tr></table>>];
+  8 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 0:Z,100:Z</b></td></tr><tr><td><font color="darkgray">node: 8</font></td></tr></table>>];
   0 -> 4;
+  0 -> 8;
+  1 -> 8;
+  4 -> 8;
   5 -> 6;
   5 -> 7;
   6 -> 7;

--- a/regression_tests/cases/print_dag/print_dag.input_qasm.case.sh
+++ b/regression_tests/cases/print_dag/print_dag.input_qasm.case.sh
@@ -1,0 +1,21 @@
+INPUT="
+OPENQASM 2.0;
+include \"qelib1.inc\";
+
+qreg q[15];
+
+cx q[0],q[1];
+crz(pi/16) q[0],q[2];
+cx q[5],q[6];
+crz(pi/16) q[6],q[7];
+h q[0];
+h q[1];
+h q[2];
+h q[5];
+h q[6];
+h q[7];
+cx q[7],q[8];
+cx q[6],q[8];
+"
+
+echo "$INPUT" | lsqecc_slicer -q --printdag input

--- a/regression_tests/cases/print_dag/print_dag.input_qasm.spec
+++ b/regression_tests/cases/print_dag/print_dag.input_qasm.spec
@@ -1,0 +1,28 @@
+digraph DirectedGraph {
+  0 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>cx q[0],q[1];</b></td></tr><tr><td><font color="darkgray">node: 0</font></td></tr></table>>];
+  1 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>crz(pi/16) q[0],q[2];</b></td></tr><tr><td><font color="darkgray">node: 1</font></td></tr></table>>];
+  2 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>cx q[5],q[6];</b></td></tr><tr><td><font color="darkgray">node: 2</font></td></tr></table>>];
+  3 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>crz(pi/16) q[6],q[7];</b></td></tr><tr><td><font color="darkgray">node: 3</font></td></tr></table>>];
+  4 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>h q[0];</b></td></tr><tr><td><font color="darkgray">node: 4</font></td></tr></table>>];
+  5 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>h q[1];</b></td></tr><tr><td><font color="darkgray">node: 5</font></td></tr></table>>];
+  6 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>h q[2];</b></td></tr><tr><td><font color="darkgray">node: 6</font></td></tr></table>>];
+  7 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>h q[5];</b></td></tr><tr><td><font color="darkgray">node: 7</font></td></tr></table>>];
+  8 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>h q[6];</b></td></tr><tr><td><font color="darkgray">node: 8</font></td></tr></table>>];
+  9 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>h q[7];</b></td></tr><tr><td><font color="darkgray">node: 9</font></td></tr></table>>];
+  10 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>cx q[7],q[8];</b></td></tr><tr><td><font color="darkgray">node: 10</font></td></tr></table>>];
+  11 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>cx q[6],q[8];</b></td></tr><tr><td><font color="darkgray">node: 11</font></td></tr></table>>];
+  0 -> 4;
+  0 -> 5;
+  1 -> 4;
+  1 -> 6;
+  2 -> 3;
+  2 -> 7;
+  2 -> 8;
+  2 -> 11;
+  3 -> 8;
+  3 -> 9;
+  3 -> 10;
+  8 -> 11;
+  9 -> 10;
+  10 -> 11;
+}

--- a/regression_tests/cases/print_dag/print_dag.processed_lli.case.sh
+++ b/regression_tests/cases/print_dag/print_dag.processed_lli.case.sh
@@ -1,0 +1,6 @@
+INPUT="
+DeclareLogicalQubitPatches 0,1,2,3,4,5,6
+MultiBodyMeasure 0:X,4:X
+MultiBodyMeasure 0:Z,4:Z
+"
+echo "$INPUT" | lsqecc_slicer --printdag -L compact --printdag processedlli

--- a/regression_tests/cases/print_dag/print_dag.processed_lli.spec
+++ b/regression_tests/cases/print_dag/print_dag.processed_lli.spec
@@ -1,0 +1,11 @@
+digraph DirectedGraph {
+  0 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 0:X,4:X</b></td></tr><tr><td><font color="darkgray">node: 0</font></td></tr></table>>];
+  1 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>RotateSingleCellPatch 0</b></td></tr><tr><td><font color="darkgray">node: 1</font></td></tr></table>>];
+  2 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>RotateSingleCellPatch 4</b></td></tr><tr><td><font color="darkgray">node: 2</font></td></tr></table>>];
+  3 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 0:Z,4:Z</b></td></tr><tr><td><font color="darkgray">node: 3</font></td></tr></table>>];
+  0 -> 1;
+  0 -> 2;
+  0 -> 3;
+  1 -> 3;
+  2 -> 3;
+}

--- a/regression_tests/cases/print_dag/print_dag.un_processed_lli.case.sh
+++ b/regression_tests/cases/print_dag/print_dag.un_processed_lli.case.sh
@@ -1,0 +1,6 @@
+INPUT="
+DeclareLogicalQubitPatches 0,1,2,3,4,5,6
+MultiBodyMeasure 0:X,4:X
+MultiBodyMeasure 0:Z,4:Z
+"
+echo "$INPUT" | lsqecc_slicer --printdag -L compact --printdag input

--- a/regression_tests/cases/print_dag/print_dag.un_processed_lli.spec
+++ b/regression_tests/cases/print_dag/print_dag.un_processed_lli.spec
@@ -1,0 +1,5 @@
+digraph DirectedGraph {
+  0 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 0:X,4:X</b></td></tr><tr><td><font color="darkgray">node: 0</font></td></tr></table>>];
+  1 [shape="plaintext",label=<<table cellborder="0"><tr><td><b>MultiBodyMeasure 0:Z,4:Z</b></td></tr><tr><td><font color="darkgray">node: 1</font></td></tr></table>>];
+  0 -> 1;
+}

--- a/src/dag/domain_dags.cpp
+++ b/src/dag/domain_dags.cpp
@@ -1,0 +1,31 @@
+#include <lsqecc/dag/domain_dags.hpp>
+
+
+
+namespace lsqecc::dag
+{
+
+
+
+DependencyDag<LSInstruction> full_dependency_dag_from_instruction_stream(LSInstructionStream& instruction_stream)
+{
+    DependencyDag<LSInstruction> dag;
+    while (instruction_stream.has_next_instruction())
+        dag.push_instruction(instruction_stream.get_next_instruction());
+
+    return dag;
+}
+
+
+
+DependencyDag<gates::Gate> full_dependency_dag_from_gate_stream(GateStream& gate_stream)
+{
+    DependencyDag<gates::Gate> dag;
+    while (gate_stream.has_next_gate())
+        dag.push_instruction(gate_stream.get_next_gate());
+
+    return dag;
+}
+
+} // namespace lsqecc::dag
+

--- a/src/gates/gates.cpp
+++ b/src/gates/gates.cpp
@@ -190,8 +190,10 @@ std::ostream& operator<<(std::ostream& os, const gates::Gate& gate)
                     }() << " q[" << ctrld.control_qubit << "],q[" << gate.target_qubit << "];";
                 },
                 [&](const RZ& rz){
-                    os << "crz("<<rz.pi_fraction.num<<"pi/"<<rz.pi_fraction.den
-                       << ") q[" << ctrld.control_qubit << "," << rz.target_qubit << "];";
+                    os << "crz(";
+                    if(rz.pi_fraction.num != 1)
+                        os << rz.pi_fraction.num << "*pi";
+                    os <<"pi/"<<rz.pi_fraction.den << ") q[" << ctrld.control_qubit << "],q[" << rz.target_qubit << "];";
                 },
             }, ctrld.target_gate);
         },

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -10,28 +10,36 @@ namespace lsqecc {
 tsl::ordered_set<PatchId> LSInstruction::get_operating_patches() const
 {
     tsl::ordered_set<PatchId> ret;
-    if (const auto* s = std::get_if<SinglePatchMeasurement>(&operation))
-    {
-        ret.insert(s->target);
-    }
-    else if (const auto* p = std::get_if<SingleQubitOp>(&operation))
-    {
-        ret.insert(p->target);
-    }
-    else if (const auto* m = std::get_if<MultiPatchMeasurement>(&operation))
-    {
-        for(auto pair : m->observable)
-        {
-            ret.insert(pair.first);
+    std::visit(lstk::overloaded{
+        [&](const SinglePatchMeasurement& op){
+            ret.insert(op.target);
+        },
+        [&](const MultiPatchMeasurement& op){
+            for(const auto& [patch_id, local_observable] : op.observable)
+                ret.insert(patch_id);
+        },
+        [&](const PatchInit& op){
+            ret.insert(op.target);
+        },
+        [&](const MagicStateRequest& op){
+            ret.insert(op.target);
+        },
+        [&](const SingleQubitOp& op){
+            ret.insert(op.target);
+        },
+        [&](const RotateSingleCellPatch& op){
+            ret.insert(op.target);
+        },
+        [&](const BusyRegion& op){
+            if(op.state_after_clearing.id) ret.insert(*op.state_after_clearing.id);
+        },
+        [&](const DeclareLogicalQubitPatches& op){
+            LSTK_NOOP;
+        },
+        [&](const auto& op){
+            LSTK_UNREACHABLE;
         }
-    }
-    else if (const auto* rotation = std::get_if<RotateSingleCellPatch>(&operation)) {
-        ret.insert(rotation->target);
-    }
-    else {
-        const auto& mr = std::get<MagicStateRequest>(operation);
-        ret.insert(mr.target);
-    }
+    }, operation);
     return ret;
 }
 

--- a/src/ls_instructions/ls_instructions.cpp
+++ b/src/ls_instructions/ls_instructions.cpp
@@ -7,30 +7,30 @@
 namespace lsqecc {
 
 
-std::vector<PatchId> LSInstruction::get_operating_patches() const
+tsl::ordered_set<PatchId> LSInstruction::get_operating_patches() const
 {
-    std::vector<PatchId> ret;
+    tsl::ordered_set<PatchId> ret;
     if (const auto* s = std::get_if<SinglePatchMeasurement>(&operation))
     {
-        ret.push_back(s->target);
+        ret.insert(s->target);
     }
     else if (const auto* p = std::get_if<SingleQubitOp>(&operation))
     {
-        ret.push_back(p->target);
+        ret.insert(p->target);
     }
     else if (const auto* m = std::get_if<MultiPatchMeasurement>(&operation))
     {
         for(auto pair : m->observable)
         {
-            ret.push_back(pair.first);
+            ret.insert(pair.first);
         }
     }
     else if (const auto* rotation = std::get_if<RotateSingleCellPatch>(&operation)) {
-        ret.push_back(rotation->target);
+        ret.insert(rotation->target);
     }
     else {
         const auto& mr = std::get<MagicStateRequest>(operation);
-        ret.push_back(mr.target);
+        ret.insert(mr.target);
     }
     return ret;
 }

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -122,7 +122,7 @@ namespace lsqecc
                 .required(false);
         parser.add_argument()
                 .names({"--printdag"})
-                .description("Prints a dependancy dag of the circuit. Modes: input (default), qasm, processedlli")
+                .description("Prints a dependancy dag of the circuit. Modes: input (default), processedlli")
                 .required(false);
         parser.add_argument()
                 .names({"--noslices"})

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -1,5 +1,6 @@
 #include <lsqecc/pipelines/slicer.hpp>
 
+#include <lsqecc/dag/domain_dags.hpp>
 #include <lsqecc/gates/parse_gates.hpp>
 #include <lsqecc/gates/clifford_plus_t_conversion_stream.hpp>
 #include <lsqecc/ls_instructions/ls_instruction_stream.hpp>
@@ -55,7 +56,9 @@ namespace lsqecc
     };
 
 
-    // TODO: Resume by getting the slicer to accept stdin as input
+    enum class PrintDagMode {
+        None, Input, ProcessedLli
+     };
 
 
     DistillationOptions make_distillation_options(argparse::ArgumentParser& parser)
@@ -116,6 +119,10 @@ namespace lsqecc
         parser.add_argument()
                 .names({"--printlli"})
                 .description("Output LLI instead of JSONs")
+                .required(false);
+        parser.add_argument()
+                .names({"--printdag"})
+                .description("Prints a dependancy dag of the circuit. Modes: input (default), qasm, processedlli")
                 .required(false);
         parser.add_argument()
                 .names({"--noslices"})
@@ -194,6 +201,22 @@ namespace lsqecc
             }
         }
 
+        PrintDagMode print_dag_mode = PrintDagMode::None;
+        if (parser.exists("printdag"))
+        {
+            auto mode_arg = parser.get<std::string>("printdag");
+            if (mode_arg=="input" || mode_arg=="")
+                print_dag_mode = PrintDagMode::Input;
+            else if (mode_arg=="processedlli")
+                print_dag_mode = PrintDagMode::ProcessedLli;
+            else
+            {
+                err_stream << "Unknown print dag mode " << mode_arg << std::endl;
+                return -1;
+            }
+        }
+        
+
         std::reference_wrapper<std::istream> input_file_stream = std::ref(in_stream);
         std::unique_ptr<std::ifstream> _file_to_read_store;
         if(parser.exists("i"))
@@ -215,10 +238,24 @@ namespace lsqecc
             instruction_stream = std::make_unique<LSInstructionStreamFromFile>(input_file_stream.get());
             id_generator.set_start(*std::max(instruction_stream->core_qubits().begin(),
                                              instruction_stream->core_qubits().end()));
+            if( print_dag_mode == PrintDagMode::Input )
+            {
+                auto dag = dag::full_dependency_dag_from_instruction_stream(*instruction_stream);
+                dag.to_graphviz(out_stream);
+                return 0;
+            }
         }
         if(parser.exists("q"))
         {
             gate_stream = std::make_unique<GateStreamFromFile>(input_file_stream.get());
+
+            if (print_dag_mode == PrintDagMode::Input)
+            {
+                auto dag = dag::full_dependency_dag_from_gate_stream(*gate_stream);
+                dag.to_graphviz(out_stream);
+                return 0;
+            }
+
             gate_stream = std::make_unique<CliffordPlusTConversionStream>(
                 std::move(gate_stream),
                 parser.exists("rzprecision") ? parser.get<double>("rzprecision") : k_default_precision_log_ten_negative
@@ -237,9 +274,11 @@ namespace lsqecc
                     return -1;
                 }
             }
+
             id_generator.set_start(gate_stream->get_qreg().size);
-            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream, cnot_correction_mode, id_generator);
+            instruction_stream = std::make_unique<LSInstructionStreamFromGateStream>(*gate_stream, cnot_correction_mode, id_generator);    
         }
+
 
         std::unique_ptr<Layout> layout;
         DistillationOptions distillation_options = make_distillation_options(parser);
@@ -270,6 +309,11 @@ namespace lsqecc
         if(parser.exists("printlli"))
         {
             print_all_ls_instructions_to_string(out_stream, std::move(instruction_stream));
+            return 0;
+        } else if (print_dag_mode == PrintDagMode::ProcessedLli)
+        {
+            auto dag = dag::full_dependency_dag_from_instruction_stream(*instruction_stream);
+            dag.to_graphviz(out_stream);
             return 0;
         }
 

--- a/tests/dag/dependency_dag.cpp
+++ b/tests/dag/dependency_dag.cpp
@@ -17,7 +17,7 @@ std::ostream& operator<<(std::ostream& os, const TestInstruction& instruction)
 
 
 namespace lsqecc::dag {
-template<> // TODO replace with concepts
+template<>
 struct CommutationTrait<TestInstruction> {
     static bool can_commute(const TestInstruction& lhs, const TestInstruction& rhs)
     {

--- a/tests/dag/domain_dags.cpp
+++ b/tests/dag/domain_dags.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+
+#include <lsqecc/dag/domain_dags.hpp>
+
+using namespace lsqecc;
+
+#define COMMA ,
+
+TEST(commutation_trait, can_commute)
+{
+    ASSERT_TRUE(dag::CommutationTrait<gates::Gate>::can_commute(gates::X(0) COMMA gates::X(1)));
+    ASSERT_FALSE(dag::CommutationTrait<gates::Gate>::can_commute(gates::X(0) COMMA gates::X(0)));
+
+    ASSERT_TRUE(dag::CommutationTrait<gates::Gate>::can_commute(gates::CNOT(0 COMMA 1) COMMA gates::CNOT(2 COMMA 3))); // All different
+    ASSERT_TRUE(dag::CommutationTrait<gates::Gate>::can_commute(gates::CNOT(0 COMMA 2) COMMA gates::CNOT(1 COMMA 2))); // Same control
+    ASSERT_FALSE(dag::CommutationTrait<gates::Gate>::can_commute(gates::CNOT(0 COMMA 1) COMMA gates::CNOT(0 COMMA 2))); // Same target
+    ASSERT_FALSE(dag::CommutationTrait<gates::Gate>::can_commute(gates::CNOT(0 COMMA 1) COMMA gates::CNOT(0 COMMA 1))); // All the same
+}

--- a/tests/lstk/lstk.cpp
+++ b/tests/lstk/lstk.cpp
@@ -53,3 +53,23 @@ TEST(split_on, pi_over_group)
     ASSERT_EQ("2",splits1.at(1));
 }
 
+
+
+TEST(set_intersection, empty)
+{
+    tsl::ordered_set<int> a = {1,2,3};
+    tsl::ordered_set<int> b = {4,5,6};
+    tsl::ordered_set<int> c = lstk::set_intersection(a,b);
+    ASSERT_TRUE(c.empty());
+}
+
+TEST(set_intersection, non_empty)
+{
+    tsl::ordered_set<int> a = {1,2,3};
+    tsl::ordered_set<int> b = {2,3,4};
+    tsl::ordered_set<int> c = lstk::set_intersection(a,b);
+    ASSERT_EQ(2,c.size());
+    ASSERT_EQ(1,c.count(2));
+    ASSERT_EQ(1,c.count(3));
+}
+


### PR DESCRIPTION
This patch has no influence on the usual compilation pipeline. It just adds the ability to print dependency DAGs. Arrows indicate that the pointed-to instruction can only take place after the pointed-from instruction.

Uses the data structures introduced with:
 * #65 
 * #63 

# Usage:
Use the `--printdag` flag to print a dag instead of compiling.

#  Examples
## QASM
```
OPENQASM 2.0;
include \"qelib1.inc\";

qreg q[15];

cx q[0],q[1];
crz(pi/16) q[0],q[2];
cx q[5],q[6];
crz(pi/16) q[6],q[7];
h q[0];
h q[1];
h q[2];
h q[5];
h q[6];
h q[7];
cx q[7],q[8];
cx q[6],q[8];
```
![Screenshot_20230226_180359](https://user-images.githubusercontent.com/36427091/221455091-c203559f-bf81-4730-a435-f7e3a667da76.png)

## Raw LLI
```
DeclareLogicalQubitPatches 0,1,2,3,4,5,6
MultiBodyMeasure 0:X,4:X
MultiBodyMeasure 0:Z,4:Z
```
![Screenshot_20230226_180631](https://user-images.githubusercontent.com/36427091/221455343-b813e71b-71d0-49c5-b5d2-25f62c584465.png)

## Raw LLI after processing
Same LLI as above, but in this case the boundary rotations were inserted
![Screenshot_20230226_180757](https://user-images.githubusercontent.com/36427091/221455497-4a3d83b5-d17c-41e7-a276-622c179e3f6d.png)

## More complicated LLI
```
DeclareLogicalQubitPatches 0,1,2,3,4,5,6
Init 100 +
MultiBodyMeasure 0:X,4:X
MultiBodyMeasure 5:Z,6:Z
MultiBodyMeasure 2:Z,3:Z
RotateSingleCellPatch 100
HGate 1
HGate 1
RotateSingleCellPatch 1
MultiBodyMeasure 0:Z,100:Z
```
![Screenshot_20230226_181103](https://user-images.githubusercontent.com/36427091/221455843-f7d733a1-b5c2-455a-9d09-adc1a08f1c5e.png)


