### PR TITLE
Add basic statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
         src/patches/patches.cpp
         src/patches/sparse_slice.cpp
         src/patches/slices_to_json.cpp
+        src/patches/slice_stats.cpp
         src/pipelines/slicer.cpp
         src/layout/dynamic_layouts/compact_layout.cpp
 	src/layout/dynamic_layouts/edpc_layout.cpp

--- a/README.md
+++ b/README.md
@@ -37,20 +37,24 @@ Options:
     -q, --qasm             File name of file with QASM. When not provided will read as LLI (not QASM)
     -l, --layout           File name of file with layout spec, otherwise the layout is auto-generated (configure with -L)
     -o, --output           File name of output. When not provided outputs to stdout
-    -f, --output-format    Requires -o, STDOUT output format: progress, noprogress, machine
+    -f, --output-format    Requires -o, STDOUT output format: progress, noprogress, machine, stats
     -t, --timeout          Set a timeout in seconds after which stop producing slices
     -r, --router           Set a router: graph_search (default), graph_search_cached
-    -g, --graph-search     Set a graph search provider: custom (default), boost (not always available)
+    -P, --pipeline         pipeline mode: stream (default), dag
+    -g, --graph-search     Set a graph search provider: djikstra (default), astar, boost (not always available)
     --graceful             If there is an error when slicing, print the error and terminate
-    --printlli             Output LLI instead of JSONs
+    --printlli             Output LLI instead of JSONs. options: before (default), sliced (prints lli on the same slice separated by semicolons)
+    --printdag             Prints a dependancy dag of the circuit. Modes: input (default), processedlli
     --noslices             Do the slicing but don't write the slices out
     --cnotcorrections      Add Xs and Zs to correct the the negative outcomes: never (default), always
     --layoutgenerator, -L  Automatically generates a layout for the given number of qubits. Incompatible with -l. Options:
                             - compact (default): Uses Litinski's Game of Surace Code compact layout (https://arxiv.org/abs/1808.02892)
+                            - compact_no_clogging: same as compact, but fewer cells for ancillas and magic state queues
                             - edpc: Uses a layout specified in the EDPC paper by Beverland et. al. (https://arxiv.org/abs/2110.11493)
     --nostagger            Turns off staggered distillation block timing
     --disttime             Set the distillation time (default 10)
-    -h, --help             Shows this page        
+    --local                Compile gates using a local lattice surgery instruction set
+    -h, --help             Shows this page 
 ```
 #### QASM Support (Experimental)
 LibLSQECC can parse a small subset of OpenQASM 2.0 instead of LLI, with restrictions below. We call this type of assembly OpenQASM--. In general OpenQASM-- should be valid OpenQASM, up to implementation defects. The rules are 

--- a/include/lsqecc/patches/slice_stats.hpp
+++ b/include/lsqecc/patches/slice_stats.hpp
@@ -13,6 +13,7 @@ struct VolumeCounts
     size_t volume = 0;
     size_t unused_routing_volume = 0;
     size_t distillation_volume = 0;
+    size_t dead = 0;
 };
 
 VolumeCounts operator+=(VolumeCounts& lhs, const VolumeCounts& rhs);
@@ -23,9 +24,9 @@ struct SliceStats
     // More metrics to go here, e.g. time between magic state requests etc.
 };
 
+std::ostream& operator<<(std::ostream& os, const SliceStats& slice_stats);
 
 VolumeCounts compute_volume_counts(const DenseSlice& slice);
-
 
 
 } // namespace lsqecc

--- a/include/lsqecc/patches/slice_stats.hpp
+++ b/include/lsqecc/patches/slice_stats.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+#include <lsqecc/patches/dense_slice.hpp>
+
+namespace lsqecc {
+
+
+struct VolumeCounts
+{
+    size_t volume = 0;
+    size_t unused_routing_volume = 0;
+    size_t distillation_volume = 0;
+};
+
+VolumeCounts operator+=(VolumeCounts& lhs, const VolumeCounts& rhs);
+
+struct SliceStats
+{
+    VolumeCounts totals;
+    // More metrics to go here, e.g. time between magic state requests etc.
+};
+
+
+VolumeCounts compute_volume_counts(const DenseSlice& slice);
+
+
+
+} // namespace lsqecc

--- a/regression_tests/cases/help.spec
+++ b/regression_tests/cases/help.spec
@@ -4,7 +4,7 @@ Options:
     -q, --qasm             File name of file with QASM. When not provided will read as LLI (not QASM)
     -l, --layout           File name of file with layout spec, otherwise the layout is auto-generated (configure with -L)
     -o, --output           File name of output. When not provided outputs to stdout
-    -f, --output-format    Requires -o, STDOUT output format: progress, noprogress, machine
+    -f, --output-format    Requires -o, STDOUT output format: progress, noprogress, machine, stats
     -t, --timeout          Set a timeout in seconds after which stop producing slices
     -r, --router           Set a router: graph_search (default), graph_search_cached
     -P, --pipeline         pipeline mode: stream (default), dag

--- a/regression_tests/cases/stats/1.case.sh
+++ b/regression_tests/cases/stats/1.case.sh
@@ -1,0 +1,9 @@
+INPUT="
+OPENQASM 2.0;
+include \"qelib1.inc\";
+
+qreg q[15];
+"
+# Manually counted
+echo "$INPUT" | lsqecc_slicer -o count.json -q -L compact -f stats | \
+  sed "s/Made patch computation. Took [0-9]*.[0-9e\-]*s./Made patch computation. Took <time_removed_by_case_script>/"

--- a/regression_tests/cases/stats/1.spec
+++ b/regression_tests/cases/stats/1.spec
@@ -4,4 +4,5 @@ Made patch computation. Took <time_removed_by_case_script>
 Total volume: 48
 Distillation volume: 15 (31.25%)
 Unused routing volume: 18 (37.5%)
+Dead volume: 0 (0%)
 Other active volume: 18 (31.25%)

--- a/regression_tests/cases/stats/1.spec
+++ b/regression_tests/cases/stats/1.spec
@@ -5,4 +5,4 @@ Total volume: 48
 Distillation volume: 15 (31.25%)
 Unused routing volume: 18 (37.5%)
 Dead volume: 0 (0%)
-Other active volume: 18 (31.25%)
+Other active volume: 15 (31.25%)

--- a/regression_tests/cases/stats/1.spec
+++ b/regression_tests/cases/stats/1.spec
@@ -4,3 +4,4 @@ Made patch computation. Took <time_removed_by_case_script>
 Total volume: 48
 Distillation volume: 15 (31.25%)
 Unused routing volume: 18 (37.5%)
+Other active volume: 18 (31.25%)

--- a/regression_tests/cases/stats/1.spec
+++ b/regression_tests/cases/stats/1.spec
@@ -1,0 +1,6 @@
+LS Instructions read  0
+Slices 1
+Made patch computation. Took <time_removed_by_case_script>
+Total volume: 48
+Distillation volume: 15 (31.25%)
+Unused routing volume: 18 (37.5%)

--- a/regression_tests/cases/stats/2.case.sh
+++ b/regression_tests/cases/stats/2.case.sh
@@ -1,0 +1,14 @@
+INPUT="
+OPENQASM 2.0;
+include \"qelib1.inc\";
+
+qreg q[15];
+
+cx q[0],q[10];
+s q[1];
+cx q[1],q[3];
+cx q[5],q[7];
+t q[2];
+"
+echo "$INPUT" | lsqecc_slicer --noslices -q -L compact -f stats | \
+  sed "s/Made patch computation. Took [0-9]*.[0-9e\-]*s./Made patch computation. Took <time_removed_by_case_script>/"

--- a/regression_tests/cases/stats/2.spec
+++ b/regression_tests/cases/stats/2.spec
@@ -4,4 +4,5 @@ Made patch computation. Took <time_removed_by_case_script>
 Total volume: 1008
 Distillation volume: 315 (31.25%)
 Unused routing volume: 265 (26.2897%)
+Dead volume: 0 (0%)
 Other active volume: 265 (42.4603%)

--- a/regression_tests/cases/stats/2.spec
+++ b/regression_tests/cases/stats/2.spec
@@ -5,4 +5,4 @@ Total volume: 1008
 Distillation volume: 315 (31.25%)
 Unused routing volume: 265 (26.2897%)
 Dead volume: 0 (0%)
-Other active volume: 265 (42.4603%)
+Other active volume: 428 (42.4603%)

--- a/regression_tests/cases/stats/2.spec
+++ b/regression_tests/cases/stats/2.spec
@@ -1,0 +1,6 @@
+LS Instructions read  27
+Slices 11
+Made patch computation. Took <time_removed_by_case_script>
+Total volume: 1008
+Distillation volume: 315 (31.25%)
+Unused routing volume: 265 (26.2897%)

--- a/regression_tests/cases/stats/2.spec
+++ b/regression_tests/cases/stats/2.spec
@@ -4,3 +4,4 @@ Made patch computation. Took <time_removed_by_case_script>
 Total volume: 1008
 Distillation volume: 315 (31.25%)
 Unused routing volume: 265 (26.2897%)
+Other active volume: 265 (42.4603%)

--- a/regression_tests/cases/stats/3.case.sh
+++ b/regression_tests/cases/stats/3.case.sh
@@ -1,0 +1,8 @@
+INPUT="
+OPENQASM 2.0;
+include \"qelib1.inc\";
+
+qreg q[25];
+"
+echo "$INPUT" | lsqecc_slicer -o test.json -q -L edpc -f stats | \
+  sed "s/Made patch computation. Took [0-9]*.[0-9e\-]*s./Made patch computation. Took <time_removed_by_case_script>/"

--- a/regression_tests/cases/stats/3.spec
+++ b/regression_tests/cases/stats/3.spec
@@ -5,4 +5,4 @@ Total volume: 441
 Distillation volume: 156 (35.3741%)
 Unused routing volume: 120 (27.2109%)
 Dead volume: 128 (29.0249%)
-Other active volume: 120 (8.39002%)
+Other active volume: 37 (8.39002%)

--- a/regression_tests/cases/stats/3.spec
+++ b/regression_tests/cases/stats/3.spec
@@ -1,0 +1,8 @@
+LS Instructions read  0
+Slices 1
+Made patch computation. Took <time_removed_by_case_script>
+Total volume: 441
+Distillation volume: 156 (35.3741%)
+Unused routing volume: 120 (27.2109%)
+Dead volume: 128 (29.0249%)
+Other active volume: 120 (8.39002%)

--- a/src/patches/slice_stats.cpp
+++ b/src/patches/slice_stats.cpp
@@ -17,11 +17,10 @@ std::ostream& operator<<(std::ostream& os, const SliceStats& slice_stats)
     os << "Dead volume: "
         << slice_stats.totals.dead
         << " (" << get_percentage_volume(slice_stats.totals.dead) << "%)" << std::endl;
+    auto other_volume = slice_stats.totals.volume - slice_stats.totals.unused_routing_volume - slice_stats.totals.distillation_volume - slice_stats.totals.dead;
     os << "Other active volume: " 
-        << slice_stats.totals.unused_routing_volume 
-        << " (" << get_percentage_volume(
-            slice_stats.totals.volume - slice_stats.totals.unused_routing_volume - slice_stats.totals.distillation_volume - slice_stats.totals.dead) 
-        << "%)";
+        << other_volume
+        << " (" << get_percentage_volume(other_volume) << "%)";
     return os;
 }
 

--- a/src/patches/slice_stats.cpp
+++ b/src/patches/slice_stats.cpp
@@ -2,12 +2,35 @@
 
 namespace lsqecc {
 
+std::ostream& operator<<(std::ostream& os, const SliceStats& slice_stats)
+{
+    auto get_percentage_volume = [&](size_t x) -> double {
+                    return static_cast<double>(x) / static_cast<double>(slice_stats.totals.volume) * 100.0;
+    };
+    os << "Total volume: " << slice_stats.totals.volume << std::endl;
+    os << "Distillation volume: " 
+        << slice_stats.totals.distillation_volume 
+        << " (" << get_percentage_volume(slice_stats.totals.distillation_volume) << "%)" << std::endl;
+    os << "Unused routing volume: " 
+        << slice_stats.totals.unused_routing_volume 
+        << " (" << get_percentage_volume(slice_stats.totals.unused_routing_volume) << "%)" << std::endl;
+    os << "Dead volume: "
+        << slice_stats.totals.dead
+        << " (" << get_percentage_volume(slice_stats.totals.dead) << "%)" << std::endl;
+    os << "Other active volume: " 
+        << slice_stats.totals.unused_routing_volume 
+        << " (" << get_percentage_volume(
+            slice_stats.totals.volume - slice_stats.totals.unused_routing_volume - slice_stats.totals.distillation_volume - slice_stats.totals.dead) 
+        << "%)";
+    return os;
+}
 
 VolumeCounts operator+=(VolumeCounts& lhs, const VolumeCounts& rhs)
 {
     lhs.volume += rhs.volume;
     lhs.unused_routing_volume += rhs.unused_routing_volume;
     lhs.distillation_volume += rhs.distillation_volume;
+    lhs.dead += rhs.dead;
     return lhs;
 }
 
@@ -21,9 +44,11 @@ VolumeCounts compute_volume_counts(const DenseSlice& slice)
         for (const auto& cell : row)
         {
             if (!cell.has_value())
-                counts.unused_routing_volume += 1; 
-            else if (cell->type == PatchType::Distillation) 
+                counts.unused_routing_volume += 1;
+            else if (cell->type == PatchType::Distillation)
                 counts.distillation_volume += 1;
+            else if (cell->type == PatchType::Dead)
+                counts.dead += 1;
         }
     }
     return counts;

--- a/src/patches/slice_stats.cpp
+++ b/src/patches/slice_stats.cpp
@@ -1,0 +1,33 @@
+#include <lsqecc/patches/slice_stats.hpp>
+
+namespace lsqecc {
+
+
+VolumeCounts operator+=(VolumeCounts& lhs, const VolumeCounts& rhs)
+{
+    lhs.volume += rhs.volume;
+    lhs.unused_routing_volume += rhs.unused_routing_volume;
+    lhs.distillation_volume += rhs.distillation_volume;
+    return lhs;
+}
+
+
+VolumeCounts compute_volume_counts(const DenseSlice& slice)
+{
+    VolumeCounts counts;
+    counts.volume = (slice.layout.get().furthest_cell().row+1) * (slice.layout.get().furthest_cell().col+1);
+    for (const auto& row : slice.cells) 
+    {
+        for (const auto& cell : row)
+        {
+            if (!cell.has_value())
+                counts.unused_routing_volume += 1; 
+            else if (cell->type == PatchType::Distillation) 
+                counts.distillation_volume += 1;
+        }
+    }
+    return counts;
+}
+
+
+} // namespace lsqecc

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -525,6 +525,11 @@ namespace lsqecc
                 out_stream << "Unused routing volume: " 
                     << slice_stats.totals.unused_routing_volume 
                     << " (" << get_percentage_volume(slice_stats.totals.unused_routing_volume) << "%)" << std::endl;
+            out_stream << "Other active volume: " 
+                    << slice_stats.totals.unused_routing_volume 
+                    << " (" << get_percentage_volume(
+                        slice_stats.totals.volume - slice_stats.totals.unused_routing_volume - slice_stats.totals.distillation_volume) 
+                    << "%)" << std::endl;
             }
         }
         

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -514,23 +514,8 @@ namespace lsqecc
             }
             
             if ( output_format_mode == OutputFormatMode::Stats)
-            {
-                auto get_percentage_volume = [&](size_t x) -> double {
-                    return static_cast<double>(x) / static_cast<double>(slice_stats.totals.volume) * 100.0;
-                };
-                out_stream << "Total volume: " << slice_stats.totals.volume << std::endl;
-                out_stream << "Distillation volume: " 
-                    << slice_stats.totals.distillation_volume 
-                    << " (" << get_percentage_volume(slice_stats.totals.distillation_volume) << "%)" << std::endl;
-                out_stream << "Unused routing volume: " 
-                    << slice_stats.totals.unused_routing_volume 
-                    << " (" << get_percentage_volume(slice_stats.totals.unused_routing_volume) << "%)" << std::endl;
-            out_stream << "Other active volume: " 
-                    << slice_stats.totals.unused_routing_volume 
-                    << " (" << get_percentage_volume(
-                        slice_stats.totals.volume - slice_stats.totals.unused_routing_volume - slice_stats.totals.distillation_volume) 
-                    << "%)" << std::endl;
-            }
+                out_stream << slice_stats << std::endl; 
+                
         }
         
         if(print_slices)

--- a/src/pipelines/slicer.cpp
+++ b/src/pipelines/slicer.cpp
@@ -13,6 +13,7 @@
 #include <lsqecc/layout/dynamic_layouts/edpc_layout.hpp>
 #include <lsqecc/patches/slices_to_json.hpp>
 #include <lsqecc/patches/slice.hpp>
+#include <lsqecc/patches/slice_stats.hpp>
 #include <lsqecc/patches/dense_patch_computation.hpp>
 #include <lsqecc/patches/slice_variant.hpp>
 
@@ -50,10 +51,9 @@ namespace lsqecc
         return std::string{buffer.str()};
     }
 
-
     enum class OutputFormatMode
     {
-        Progress, NoProgress, Machine
+        Progress, NoProgress, Machine, Stats
     };
 
     enum class PrintDagMode {
@@ -111,7 +111,7 @@ namespace lsqecc
                 .required(false);
         parser.add_argument()
                 .names({"-f", "--output-format"})
-                .description("Requires -o, STDOUT output format: progress, noprogress, machine")
+                .description("Requires -o, STDOUT output format: progress, noprogress, machine, stats")
                 .required(false);
         parser.add_argument()
                 .names({"-t", "--timeout"})
@@ -210,6 +210,8 @@ namespace lsqecc
                 output_format_mode = OutputFormatMode::NoProgress;
             else if (mode_arg=="machine")
                 output_format_mode = OutputFormatMode::Machine;
+            else if (mode_arg=="stats")
+                output_format_mode = OutputFormatMode::Stats;
             else
             {
                 err_stream << "Unknown output format mode " << mode_arg << std::endl;
@@ -456,6 +458,16 @@ namespace lsqecc
         }
 
 
+        SliceStats slice_stats;
+        if (output_format_mode == OutputFormatMode::Stats)
+        {
+            slice_visitor = [&, slice_visitor](const DenseSlice & s)
+            {
+                slice_visitor(s);
+                slice_stats.totals += compute_volume_counts(s);
+            };
+        }
+
         LSInstructionVisitor instruction_visitor{[&](const LSInstruction& i){}};
         if (lli_print_mode == LLIPrintMode::Sliced)
         {
@@ -494,11 +506,25 @@ namespace lsqecc
                 out_stream << computation_result->ls_instructions_count() << ","
                            << computation_result->slice_count() << ","
                            << lstk::seconds_since(start) << std::endl;
-            } else if (output_format_mode == OutputFormatMode::Progress)
+            } else if (output_format_mode == OutputFormatMode::Progress || output_format_mode == OutputFormatMode::Stats )
             {
                 out_stream << "LS Instructions read  " << computation_result->ls_instructions_count() << std::endl;
                 out_stream << "Slices " << computation_result->slice_count() << std::endl;
                 out_stream << "Made patch computation. Took " << lstk::seconds_since(start) << "s." << std::endl;
+            }
+            
+            if ( output_format_mode == OutputFormatMode::Stats)
+            {
+                auto get_percentage_volume = [&](size_t x) -> double {
+                    return static_cast<double>(x) / static_cast<double>(slice_stats.totals.volume) * 100.0;
+                };
+                out_stream << "Total volume: " << slice_stats.totals.volume << std::endl;
+                out_stream << "Distillation volume: " 
+                    << slice_stats.totals.distillation_volume 
+                    << " (" << get_percentage_volume(slice_stats.totals.distillation_volume) << "%)" << std::endl;
+                out_stream << "Unused routing volume: " 
+                    << slice_stats.totals.unused_routing_volume 
+                    << " (" << get_percentage_volume(slice_stats.totals.unused_routing_volume) << "%)" << std::endl;
             }
         }
         


### PR DESCRIPTION
As per offline discussion. Produces outputs like this
```
LS Instructions read  27
Slices 11
Made patch computation. Took <time_removed_by_case_script>
Total volume: 1008
Distillation volume: 315 (31.25%)
Unused routing volume: 265 (26.2897%)
```