### PR TITLE
Bump NPM package version to 2.0.0

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lattice-surgery/liblsqecc",
-  "version": "0.3.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lattice-surgery/liblsqecc",
-      "version": "0.3.1",
+      "version": "2.0.0",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@types/jest": "^29.4.0",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lattice-surgery/liblsqecc",
-  "version": "0.3.1",
+  "version": "2.0.0",
   "description": "Tools for compiling lattice surgery instructions",
   "main": "dist/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
To fix issue with workflow failing for publishing the npm package. Note that the new api options are not available in the npm package yet. 

